### PR TITLE
v2.3 release candidate

### DIFF
--- a/.github/release-coffee.md
+++ b/.github/release-coffee.md
@@ -1,0 +1,3 @@
+> ☕ **Enjoying HAGHS?** If this release makes your dashboard better, consider [buying me a coffee](https://www.buymeacoffee.com/DN91) — it keeps the project alive and the next release shipping.
+
+---

--- a/.github/release-coffee.md
+++ b/.github/release-coffee.md
@@ -1,3 +1,3 @@
-> ☕ **Enjoying HAGHS?** If this release makes your dashboard better, consider [buying me a coffee](https://www.buymeacoffee.com/DN91) — it keeps the project alive and the next release shipping.
+> ☕ **Enjoying HAGHS?** If you've ever gotten value from HAGHS, buying me a coffee is the nicest way to say so ❤️ [buy me a coffee](https://www.buymeacoffee.com/DN91), it keeps the project and me alive 😉 Thank you!
 
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -r requirements_test.txt
+      - run: ruff check .
+      - run: ruff format --check .
+
+  tests:
+    name: Pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -r requirements_test.txt
+      - run: pytest --cov=custom_components.haghs --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -24,7 +24,7 @@ jobs:
     name: Pytest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/hacs_validation.yaml
+++ b/.github/workflows/hacs_validation.yaml
@@ -4,7 +4,7 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - name: HACS Action
         uses: "hacs/action@main"
         with:

--- a/.github/workflows/hacs_validation.yaml
+++ b/.github/workflows/hacs_validation.yaml
@@ -4,7 +4,7 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v5.0.0"
       - name: HACS Action
         uses: "hacs/action@main"
         with:

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -9,5 +9,5 @@ jobs:
   hassfest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -9,5 +9,5 @@ jobs:
   hassfest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5.0.0
       - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,123 @@
+name: Augment Release Notes
+
+on:
+  release:
+    types: [published, edited]
+
+permissions:
+  contents: write
+
+jobs:
+  augment:
+    runs-on: ubuntu-latest
+    if: github.event.release.draft == false
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Build augmented body
+        id: build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          OWNER_LOGIN: ${{ github.repository_owner }}
+          TAG: ${{ github.event.release.tag_name }}
+          BODY_RAW: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+
+          COFFEE_START='<!-- haghs:auto-coffee:start -->'
+          COFFEE_END='<!-- haghs:auto-coffee:end -->'
+          CONTRIB_START='<!-- haghs:auto-contributors:start -->'
+          CONTRIB_END='<!-- haghs:auto-contributors:end -->'
+
+          # Write the original body to a file safely (no shell interpolation).
+          python3 -c 'import os,sys; sys.stdout.write(os.environ.get("BODY_RAW",""))' > body.raw
+
+          # Strip any pre-existing auto-blocks so the workflow is idempotent.
+          python3 - <<'PY' > body.stripped
+          import re
+          body = open('body.raw').read()
+          pairs = [
+              ('<!-- haghs:auto-coffee:start -->', '<!-- haghs:auto-coffee:end -->'),
+              ('<!-- haghs:auto-contributors:start -->', '<!-- haghs:auto-contributors:end -->'),
+          ]
+          for start, end in pairs:
+              body = re.sub(re.escape(start) + r'.*?' + re.escape(end) + r'\n*',
+                            '', body, flags=re.DOTALL)
+          print(body.strip('\n'), end='')
+          PY
+
+          # Find the previous published release tag (latest non-draft != this tag).
+          PREV_TAG=$(gh api "repos/$GH_REPO/releases" \
+            --jq "[.[] | select(.draft == false and .tag_name != \"$TAG\")] | .[0].tag_name // empty")
+
+          CONTRIBUTORS=""
+          if [ -n "$PREV_TAG" ]; then
+            COMPARE_JSON=$(gh api "repos/$GH_REPO/compare/$PREV_TAG...$TAG" 2>/dev/null || echo '{}')
+
+            AUTHORS=$(echo "$COMPARE_JSON" \
+              | jq -r '[.commits[]?.author.login // empty] | unique | .[]' 2>/dev/null || true)
+
+            COAUTHORS=$(echo "$COMPARE_JSON" \
+              | jq -r '.commits[]?.commit.message // empty' 2>/dev/null \
+              | grep -oE 'Co-authored-by:[^<]*<[0-9]+\+[A-Za-z0-9_-]+@users\.noreply\.github\.com>' \
+              | sed -E 's/.*<[0-9]+\+([A-Za-z0-9_-]+)@.*/\1/' \
+              | sort -u || true)
+
+            CONTRIBUTORS=$(printf '%s\n%s\n' "$AUTHORS" "$COAUTHORS" \
+              | sed '/^$/d' \
+              | grep -viE "^(${OWNER_LOGIN}|.*\[bot\])$" \
+              | sort -fu || true)
+          fi
+
+          # Coffee block (always added).
+          {
+            echo "$COFFEE_START"
+            cat .github/release-coffee.md
+            echo "$COFFEE_END"
+          } > coffee.md
+
+          # Contributors block (only if non-owner contributors exist).
+          : > contributors.md
+          if [ -n "$CONTRIBUTORS" ]; then
+            {
+              echo "$CONTRIB_START"
+              echo ""
+              echo "## Thanks"
+              echo ""
+              echo "This release wouldn't have been possible without:"
+              echo ""
+              while IFS= read -r handle; do
+                [ -n "$handle" ] && echo "- [@${handle}](https://github.com/${handle})"
+              done <<< "$CONTRIBUTORS"
+              echo ""
+              echo "$CONTRIB_END"
+            } > contributors.md
+          fi
+
+          # Assemble final body: coffee on top, user content, contributors at the bottom.
+          {
+            cat coffee.md
+            echo ""
+            cat body.stripped
+            if [ -s contributors.md ]; then
+              echo ""
+              echo ""
+              cat contributors.md
+            fi
+          } > body.new
+
+          if cmp -s body.raw body.new; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply augmented body
+        if: steps.build.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: gh release edit "$TAG" --notes-file body.new

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,6 +3,11 @@ name: Augment Release Notes
 on:
   release:
     types: [published, edited]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag of the (draft or published) release to augment'
+        required: true
 
 permissions:
   contents: write
@@ -10,11 +15,43 @@ permissions:
 jobs:
   augment:
     runs-on: ubuntu-latest
-    if: github.event.release.draft == false
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+
+      - name: Resolve tag and current body
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$DISPATCH_TAG"
+            # Look up draft or published release by tag via the full list
+            # (the /releases/tags/{tag} endpoint hides drafts).
+            BODY=$(gh api "repos/$GH_REPO/releases" \
+              --jq "[.[] | select(.tag_name == \"$TAG\")] | .[0].body // empty")
+            if [ -z "$BODY" ] && ! gh api "repos/$GH_REPO/releases" \
+                --jq "[.[] | select(.tag_name == \"$TAG\")] | length" \
+                | grep -q '^[1-9]'; then
+              echo "::error::No release (draft or published) found for tag $TAG"
+              exit 1
+            fi
+          else
+            TAG="$RELEASE_TAG"
+            BODY="$RELEASE_BODY"
+          fi
+          {
+            echo "tag=$TAG"
+          } >> "$GITHUB_OUTPUT"
+          # Pass body via file (avoids GITHUB_OUTPUT multi-line escaping).
+          printf '%s' "$BODY" > body.raw
 
       - name: Build augmented body
         id: build
@@ -22,8 +59,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           OWNER_LOGIN: ${{ github.repository_owner }}
-          TAG: ${{ github.event.release.tag_name }}
-          BODY_RAW: ${{ github.event.release.body }}
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
 
@@ -31,9 +67,6 @@ jobs:
           COFFEE_END='<!-- haghs:auto-coffee:end -->'
           CONTRIB_START='<!-- haghs:auto-contributors:start -->'
           CONTRIB_END='<!-- haghs:auto-contributors:end -->'
-
-          # Write the original body to a file safely (no shell interpolation).
-          python3 -c 'import os,sys; sys.stdout.write(os.environ.get("BODY_RAW",""))' > body.raw
 
           # Strip any pre-existing auto-blocks so the workflow is idempotent.
           python3 - <<'PY' > body.stripped
@@ -119,5 +152,5 @@ jobs:
         if: steps.build.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: gh release edit "$TAG" --notes-file body.new

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Attach HACS Release Asset
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v2.2.2)'
+        required: true
+        default: 'v2.2.2'
+
+jobs:
+  attach-zip:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Create haghs.zip
+        run: cd custom_components && zip -r ../haghs.zip haghs/
+
+      - name: Upload haghs.zip to release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          files: haghs.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+.eggs/
+build/
+dist/
+
+# Pytest / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Ruff
+.ruff_cache/
+
+# Virtual envs
+.venv/
+venv/
+env/
+
+# IDE / OS
+.idea/
+.vscode/
+*.swp
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,11 @@ closed.
 - `translations/en.json` must mirror `strings.json` 1:1.
 - Translation keys used at runtime must match exactly — mismatches are a
   blocker, not a nit.
+- For repair issues, the schema marks `issues.<id>.description` and
+  `issues.<id>.fix_flow` as mutually exclusive (`vol.Exclusive("fixable")`).
+  A fixable issue uses **only** `fix_flow` plus its inner step description;
+  putting both at the same level fails hassfest with the cryptic message
+  *"two or more values in the same group of exclusion 'fixable'"*.
 
 ### Code quality
 
@@ -93,20 +98,53 @@ closed.
 
 ## Tests
 
-Once the test infrastructure lands (see the test-bootstrap tracking issue),
-the following are required:
+The test suite lives under `tests/`. Bootstrap, migration coverage and the
+first per-pillar test landed in v2.3 (issue #54).
 
-- New scoring logic: unit tests with known input/output pairs.
+**Required for every PR that changes integration code:**
+
+- New scoring logic: unit tests with known input/output pairs. See
+  `tests/test_hardware_power.py` for the pilot pillar pattern and
+  `tests/test_zombies.py` for ratio/grace-period coverage.
 - Migration logic: tests for every branch (value present / absent, label
-  exists / doesn't exist, race conditions).
+  exists / doesn't exist, idempotency at the current version). See
+  `tests/test_migration.py`.
 
-Until then, describe your manual validation steps in the PR description
-under "Test plan".
+**Run locally:**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements_test.txt
+pytest
+pytest --cov=custom_components.haghs --cov-report=term-missing
+```
+
+`pytest-asyncio` is configured in `auto` mode in `pyproject.toml`, so async
+tests do not need a per-test marker.
+
+Manual validation steps still belong in the PR description under
+"Test plan" — they complement unit tests, not replace them.
+
+## Checks That Must Pass
+
+Three GitHub Actions workflows run on every push and PR. All must be green
+before merge:
+
+- **Hassfest** (`.github/workflows/hassfest.yaml`) — Home Assistant manifest,
+  `strings.json` / `translations` schema, integration metadata.
+- **HACS Validation** (`.github/workflows/hacs_validation.yaml`) — HACS
+  packaging and naming rules.
+- **CI** (`.github/workflows/ci.yml`) — `ruff check`, `ruff format --check`
+  and `pytest` with coverage scoped to `custom_components/haghs`.
+
+If one of these fails on your PR, fix the underlying issue rather than
+disabling the check.
 
 ## Review Process
 
 - Maintainer is `@D-N91`.
-- Responses in English only,
+- Responses in English only.
 - Expect at least one review round before merge. Don't force-push during an
   active review — append commits; the maintainer may squash on merge.
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ In **Advanced Options:**
 
 **2. Select the sensor in HAGHS:**
 
-Go to **Settings > Integrations > HAGHS > Configure** and select your new sensor in the **"Database size sensor (optional)"** field.
+Go to **Settings > Devices & Services > Integrations > HAGHS > Configure** and select your new sensor in the **"Database size sensor (optional)"** field.
 
 > **Note:** If left empty, HAGHS uses the built-in SQLite auto-detection. If you use an external database and do not provide a sensor, the database score will simply be neutral (no penalty, no monitoring). The sensor must report the value in **MB**, not bytes, not GB.
 
@@ -446,7 +446,7 @@ Each pending update costs **5 pts**. A Core version lag (≥3 months behind) add
 Entities that just became `unavailable` or `unknown` are ignored for 15 minutes. This prevents your score from dropping during brief network hiccups or device reboots. After 15 minutes, they count as zombies.
 
 **Can I change the update interval?**
-Yes. Go to **Settings > Integrations > HAGHS > Configure** and adjust the update interval (10–3600 seconds). Lower values give faster updates, higher values save resources.
+Yes. Go to **Settings > Devices & Services > Integrations > HAGHS > Configure** and adjust the update interval (10–3600 seconds). Lower values give faster updates, higher values save resources.
 
 **What happens if a sub-calculation fails?**
 HAGHS uses a safety net: if any pillar calculation times out or throws an error, it falls back to a neutral score (100 / no penalty) and logs a warning. The sensor never crashes.

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ cards:
         <details>
         <summary>{{ domain[0] | title }}: {{ domain[1] | count }}</summary>
         {% for item in domain[1] %}
-        &nbsp;&nbsp; • {{ device_attr(item.entity_id, 'name') | default('unknown device', true) }} — {{ item.name }}: {{ item.state }}
+        &nbsp;&nbsp; • {{ device_attr(item.entity_id, 'name') | default('unknown device', true) }} — {{ item.name }} (`{{ item.entity_id }}`): {{ item.state }}
         {% endfor %}
         </details>
         {% endfor %}

--- a/README.md
+++ b/README.md
@@ -469,10 +469,13 @@ cards:
         {% else %}
           {% set z_list = z_raw | list %}
         {% endif %}
-        {% set grouped = expand(z_list) | groupby('domain') %}
+        {% set ghosts = z_list | select('match', '^\\[unregistered\\]') | list %}
+        {% set tracked = z_list | reject('match', '^\\[unregistered\\]') | list %}
+        {% set grouped = expand(tracked) | groupby('domain') %}
+        {% set per_domain = state_attr(e, 'zombie_count_per_domain') | default({}, true) %}
 
-        {{ z_count }} zombie(s) across {{ grouped | length }} domain(s)
-        {% if z_count > 20 %}*(showing first 20 — {{ z_count - 20 }} more hidden)*{% endif %}
+        {{ z_count }} zombie(s) across {{ per_domain | length }} domain(s)
+        {% if z_count > 100 %}*(showing first 100 — {{ z_count - 100 }} more hidden)*{% endif %}
 
         {% set _ent = '/config/entities' %}[→ Check Entities]({{ _ent }})
 
@@ -484,6 +487,15 @@ cards:
         {% endfor %}
         </details>
         {% endfor %}
+
+        {% if ghosts | length > 0 %}
+        <details>
+        <summary>⚠️ Unregistered: {{ ghosts | length }}</summary>
+        {% for entry in ghosts %}
+        &nbsp;&nbsp; • `{{ entry | replace('[unregistered] ', '') }}`
+        {% endfor %}
+        </details>
+        {% endif %}
       {% endif %}
 
 ```

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ HAGHS exposes the following attributes for use in dashboard cards, automations, 
 | `zombie_count` | int | Total number of zombie entities |
 | `zombie_entities` | list | Entity IDs of zombies (capped at 20) |
 | `db_size_mb` | float | Current database size in MB (auto-detected for SQLite, or from external DB sensor if configured) |
-| `psi_available` | bool | Whether PSI metrics are active (CPU + RAM + I/O). When `false`, only classic sensors are used (CPU + RAM, no I/O) |
+| `psi_available` | bool | `True` when PSI provides both CPU and memory data (the prerequisite for `psi.available`). I/O PSI is read independently and may still be present when this is `False`. Disk is always read via `psutil`, never PSI. |
 | `recorder_keep_days` | int/null | Configured purge days (null = not set) |
 | `recorder_filter_active` | bool | Whether entity filters are active |
 | `pending_updates` | list | Names of pending updates (e.g., `["ESPHome 2024.2"]`) |

--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ To prevent false positives from sleeping tablets or seasonal devices:
     * **Pro Tip:** Assigning the label to a **Device** automatically whitelists **all underlying entities** belonging to that specific device.
     * **Update Tip:** Labelled update entities are excluded from the update count and penalty.
 
+### Pattern-Based Ignore (for entities without a unique ID)
+
+Some integrations (e.g. `monitor_docker`, the legacy `torque` sensor) create entities without a unique ID. These exist only in the state machine, have no entity-registry entry, and therefore cannot carry a label. HAGHS would otherwise flag them as zombies as soon as they go unavailable.
+
+Open **Settings > Devices & Services > HAGHS > Configure** and fill the **Ignore entity-id patterns** field with one glob pattern per line. Matching entities are excluded from both zombie detection and update penalties.
+
+Examples:
+- `sensor.docker_*` — every Docker monitor sensor
+- `sensor.torque_*` — every Torque OBD sensor
+- `binary_sensor.test_?` — `binary_sensor.test_1` through `binary_sensor.test_9`
+
+Wildcards `*` and `?` are supported (standard glob syntax). Invalid patterns are logged as a `WARNING` and skipped, so a single typo never disables the rest of the list.
+
 ---
 
 ## Sensor Attributes
@@ -222,6 +235,16 @@ HAGHS exposes the following attributes for use in dashboard cards, automations, 
 | `recorder_filter_active` | bool | Whether entity filters are active |
 | `pending_updates` | list | Names of pending updates (e.g., `["ESPHome 2024.2"]`) |
 | `recommendations` | string | Advisor recommendations (CPU, RAM, I/O, disk, DB, updates, zombies, backup, core lag) |
+| `rec_cpu_load` | bool | CPU load (PSI stall or classic utilization) is currently penalised |
+| `rec_ram_pressure` | bool | Memory pressure / utilization is currently penalised |
+| `rec_io_pressure` | bool | I/O PSI stall time is currently penalised |
+| `rec_disk_low` | bool | Disk free space is below the storage-type threshold |
+| `rec_db_over_limit` | bool | Database size exceeds the dynamic limit |
+| `rec_power_unstable` | bool | RPi under-voltage detected |
+| `rec_backup_stale` | bool | `binary_sensor.backups_stale` is on |
+| `rec_updates_pending` | bool | At least one non-ignored update entity is pending |
+| `rec_zombie` | bool | At least one zombie entity is reported |
+| `rec_core_lag` | bool | HA Core is ≥ 3 minor versions behind latest |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -472,10 +472,28 @@ cards:
         {% set ghosts = z_list | select('match', '^\\[unregistered\\]') | list %}
         {% set tracked = z_list | reject('match', '^\\[unregistered\\]') | list %}
         {% set grouped = expand(tracked) | groupby('domain') %}
-        {% set per_domain = state_attr(e, 'zombie_count_per_domain') | default({}, true) %}
 
-        {{ z_count }} zombie(s) across {{ per_domain | length }} domain(s)
-        {% if z_count > 100 %}*(showing first 100 — {{ z_count - 100 }} more hidden)*{% endif %}
+        {# Domain count: prefer the HAGHS v2.3+ attribute when present.
+           Fall back to extracting the distinct domains from z_list so the
+           card keeps working on older HAGHS versions that do not expose
+           zombie_count_per_domain. #}
+        {% set per_domain = state_attr(e, 'zombie_count_per_domain') %}
+        {% if per_domain %}
+          {% set domain_count = per_domain | length %}
+        {% else %}
+          {% set ns = namespace(seen=[]) %}
+          {% for entry in z_list %}
+            {% set dom = (entry | replace('[unregistered] ', '')).split('.')[0] %}
+            {% if dom not in ns.seen %}
+              {% set ns.seen = ns.seen + [dom] %}
+            {% endif %}
+          {% endfor %}
+          {% set domain_count = ns.seen | length %}
+        {% endif %}
+
+        {{ z_count }} zombie(s) across {{ domain_count }} domain(s)
+        {% if per_domain %} ({% for dom, cnt in per_domain.items() %}{{ dom }}: {{ cnt }}{% if not loop.last %}, {% endif %}{% endfor %}){% endif %}
+        {% if z_count > z_list | length %}*(showing first {{ z_list | length }} — {{ z_count - z_list | length }} more hidden)*{% endif %}
 
         {% set _ent = '/config/entities' %}[→ Check Entities]({{ _ent }})
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ cards:
 
 ```
 
-### HAGHS Pro v1.1 (Command Center)
+### HAGHS Pro v1.2 (Command Center)
 
 A comprehensive dashboard with full score breakdown, grouped zombies, database monitoring, recorder health, and deep-links.
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,12 @@ After adding it, navigate to its entity list and **manually enable** the followi
 After setup, go to **Settings > Devices & Services > Integrations > HAGHS > Configure** to adjust:
 * CPU / RAM sensors
 * Storage type
-* Ignore label
+* **Ignore labels** (multi-select)
+* **Ignore entity-id patterns** (glob list)
 * **Database size sensor** (for external databases)
 * **Update interval** (10–3600 seconds, default: 60s)
+* **Zombie grace period** (1–240 minutes, default: 15) — how long an entity must stay `unavailable` / `unknown` before it counts as a zombie. Lower values make detection more aggressive; higher values mask short outages.
+* **Battery-class grace period** (1–240 minutes, default: 60) — extended window for entities with `device_class: battery`. Zigbee / Homematic radios routinely take longer than the regular window to re-poll battery devices, so a longer default avoids false positives. Independent from the regular grace; can be set lower if you do not care about that distinction.
 
 Changes apply immediately, no restart required.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support%20my%20work-yellow?style=for-the-badge&logo=buy-me-a-coffee&logoColor=white)](https://www.buymeacoffee.com/DN91)
 ![AI-Assisted](https://img.shields.io/badge/AI-Assisted-blue?style=for-the-badge)
 
+---
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/22d138d764884b0380033fb33d7c1875)](https://app.codacy.com/gh/D-N91/home-assistant-global-health-score?utm_source=github.com&utm_medium=referral&utm_content=D-N91/home-assistant-global-health-score&utm_campaign=Badge_Grade)
+
 ## Abstract
 As Home Assistant matures into a mission-critical Smart Home OS, the need for a unified stability metric becomes paramount. **HAGHS** is a fully local, open-scoring framework designed to provide an objective **Health Score (0-100)**. It differentiates between transient hardware load and chronic maintenance neglect, providing users with a "North Star" for instance optimization. All scoring logic is fully visible in the codebase, no hidden penalties, no black boxes.
 

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ cards:
       'psi_available') | default(false, true) %} {% set _upd =
       '/config/updates' %} {% set _ent = '/config/entities' %}
 
-      | Hardware | Application | | **{{ hw }}**/100 | **{{ app }}**/100 |
+      Hardware **{{ hw }}**/100 | Application **{{ app }}**/100
 
       {% if updates | length > 0 %} 📦 {{ updates | length }} update(s) pending
       — [Open Updates]({{ _upd }}) {% endif %}
@@ -391,7 +391,7 @@ cards:
       state_attr(e, 'hardware_score') | int(0) %} {% set app = state_attr(e,
       'application_score') | int(0) %} {% set score = states(e) | int(0) %}
 
-      | Hardware | Application | | **{{ hw }}**/100 | **{{ app }}**/100 |
+      Hardware **{{ hw }}**/100 | Application **{{ app }}**/100
 
       Formula: ({{ hw }} × 0.4) + ({{ app }} × 0.6) = {{ score }}
   - type: markdown

--- a/README.md
+++ b/README.md
@@ -199,10 +199,53 @@ Go to **Settings > Devices & Services > Integrations > HAGHS > Configure** and s
 ## Label Configuration (Smart Whitelisting)
 To prevent false positives from sleeping tablets or seasonal devices:
 1.  Go to **Settings > Areas, labels & zones > Labels**.
-2.  Create a label named `haghs_ignore`.
-3.  Assign this label to any **Device**, **Entity**, or **Update Entity**.
-    * **Pro Tip:** Assigning the label to a **Device** automatically whitelists **all underlying entities** belonging to that specific device.
+2.  Create one or more labels (e.g. `haghs_ignore`, `vacation`, `guest_mode`).
+3.  Open **Settings > Devices & Services > HAGHS > Configure** and add every label you want HAGHS to honour to the **Ignore labels** field. The field accepts a list, so all listed labels are evaluated.
+4.  Assign any of those labels to any **Device**, **Entity**, or **Update Entity**.
+    * **Pro Tip:** Assigning a label to a **Device** automatically whitelists **all underlying entities** belonging to that specific device.
     * **Update Tip:** Labelled update entities are excluded from the update count and penalty.
+
+### Dynamic exclusions via automation
+
+Toggling whether HAGHS ignores a group of entities is done with Home Assistant's
+native label services — HAGHS does not need its own service. List a label like
+`vacation` in the HAGHS *Ignore labels* field, then assign/remove it from
+automations:
+
+```yaml
+# Start ignoring vacation devices at 08:00 the day you leave
+- alias: HAGHS vacation start
+  trigger:
+    - platform: time
+      at: "08:00:00"
+  action:
+    - service: label.assign
+      data:
+        label_id: vacation
+        target:
+          entity_id:
+            - light.terrace
+            - switch.coffee_machine
+            - vacuum.robot
+
+# Stop ignoring them when you are back
+- alias: HAGHS vacation end
+  trigger:
+    - platform: state
+      entity_id: input_boolean.vacation
+      to: "off"
+  action:
+    - service: label.remove
+      data:
+        label_id: vacation
+        target:
+          entity_id:
+            - light.terrace
+            - switch.coffee_machine
+            - vacuum.robot
+```
+
+HAGHS picks up the change automatically on its next refresh; no reload needed.
 
 ### Pattern-Based Ignore (for entities without a unique ID)
 

--- a/README.md
+++ b/README.md
@@ -278,8 +278,9 @@ cards:
       {% if zombies > 0 %} 🧟 {{ zombies }} zombie(s) — [Check
       Entities]({{ _ent }}) {% endif %}
 
-      {% if rec not in [none, 'unknown', 'unavailable'] and '✅' not in rec %} {%
-      else %} --- ✅ System healthy. No recommendations. {% endif %}
+      {% if rec not in [none, 'unknown', 'unavailable'] and '✅' not in rec %}
+      {{ rec }}
+      {% else %} --- ✅ System healthy. No recommendations. {% endif %}
 
       **Metric source**: {% if psi %}🟢 PSI active (CPU + RAM + I/O + Disk) —
       hardware score uses 4 components{% else %}⚙️ Classic sensors (CPU + RAM +

--- a/README.md
+++ b/README.md
@@ -425,9 +425,10 @@ cards:
         state_attr(e, 'psi_available') | default(false, true) %} {% set _upd =
         '/config/updates' %}
 
-        {% if updates | length > 0 %} {{ updates | length }} update(s) pending:
-        {% for u in updates %} &nbsp;&nbsp; • {{ u }} {% endfor %} [→ Open
-        Updates]({{ _upd }}) {% else %} ✅ All updates installed {% endif %}
+        {% if updates | length > 0 %}{{ updates | length }} update(s) pending:<br>
+        {% for u in updates %}&nbsp;&nbsp; • {{ u }}<br>{% endfor %}
+        [→ Open Updates]({{ _upd }})
+        {% else %} ✅ All updates installed {% endif %}
 
         <hr>
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ As Home Assistant matures into a mission-critical Smart Home OS, the need for a 
 - [SmartHütte Podcast](https://www.youtube.com/watch?v=G892ii7YTL8&t=48s) — Episode 30, at 0:48 (German)
 - [HomeTech.fm Podcast](https://www.youtube.com/watch?v=IrIW2VR7qic&t=3676s) — Episode 569, at 1:01:16 (English)
 - [Simon42 Youtube Video](https://www.youtube.com/watch?v=btd66ndsUuA) - Interview with D-N91, creator of HAGHS (German)
+- [Tristans Smartes Heim Youtube Video](https://www.youtube.com/watch?v=oDUdchF1mww&t=20s) - Clean up your Home Assistant (German)
 ---
 
 ### Important: Upgrading from v2.1.x to v2.2+ (Migration Error)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/d-n91/home-assistant-global-health-score?style=for-the-badge&color=green)](https://github.com/d-n91/home-assistant-global-health-score/releases)
 ![Tracked Installs](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=Tracked%20Installs&suffix=%2B&cacheSeconds=15600&style=for-the-badge&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.haghs.total)
 [![GitHub Stars](https://img.shields.io/github/stars/d-n91/home-assistant-global-health-score?style=for-the-badge&color=yellow)](https://github.com/D-N91/home-assistant-global-health-score/stargazers)
-[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support%20my%20work-yellow?style=for-the-badge&logo=buy-me-a-coffee&logoColor=white)](https://www.buymeacoffee.com/DN91)
+[![Buy Me a Coffee](https://img.shields.io/badge/Support%20My%20Work-buy%20me%20a%20coffee-yellow?style=for-the-badge&logo=buy-me-a-coffee&logoColor=white)](https://www.buymeacoffee.com/DN91)
 ![AI-Assisted](https://img.shields.io/badge/AI-Assisted-blue?style=for-the-badge)
 
 ---

--- a/README.md
+++ b/README.md
@@ -282,6 +282,14 @@ cards:
       {{ rec }}
       {% else %} --- ✅ System healthy. No recommendations. {% endif %}
 
+      {% set keep = state_attr(e, 'recorder_keep_days') %}
+      {% set filter = state_attr(e, 'recorder_filter_active') | default(false, true) %}
+      {% if keep in [none, 'unknown'] or not filter %}
+      💡 Tips to improve your score:
+      {% if keep in [none, 'unknown'] %} &nbsp;&nbsp; • Set `purge_keep_days` in your recorder configuration (+5 pts){% endif %}
+      {% if not filter %} &nbsp;&nbsp; • Configure an `include` / `exclude` entity filter for the recorder (+5 pts){% endif %}
+      {% endif %}
+
       **Metric source**: {% if psi %}🟢 PSI active (CPU + RAM + I/O + Disk) —
       hardware score uses 4 components{% else %}⚙️ Classic sensors (CPU + RAM +
       Disk) — hardware score uses 3 components{% endif %}
@@ -363,6 +371,13 @@ cards:
 
 
         {{ 'Entity filter active' if filter else 'No entity filter' }}
+
+
+        {% if keep in [none, 'unknown'] or not filter %}
+        💡 Tips to improve your score:
+        {% if keep in [none, 'unknown'] %} &nbsp;&nbsp; • Set `purge_keep_days` in your recorder configuration (+5 pts){% endif %}
+        {% if not filter %} &nbsp;&nbsp; • Configure an `include` / `exclude` entity filter for the recorder (+5 pts){% endif %}
+        {% endif %}
 
 
         ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -120,9 +120,40 @@ All work below is committed on `dev` and described in detail in
 
 ## Planned
 
-*No items currently queued for v2.4. Open issues are triaged on
-[GitHub](https://github.com/d-n91/home-assistant-global-health-score/issues)
-and added here once a concrete scope is agreed.*
+### Stale-sensor detection (v2.4)
+
+**Problem:** Sensors can fail silently — they stop reporting but Home
+Assistant keeps showing the last valid value. The current zombie
+detector only catches `unavailable` / `unknown`, so this class of
+failure goes unnoticed.
+
+**Approach — hybrid design (Option D from the v2.3 design session):**
+
+- **Always-on, passive layer:** A new `stale_candidates` state
+  attribute lists every entity whose `state.last_reported` is older
+  than a configurable threshold (default 24 h). No score impact, no
+  penalty — pure transparency, no false-positive risk for unmodified
+  setups.
+- **Opt-in, score-impacting layer:** A new `stale_watch_labels` option
+  mirrors the existing multi-label `ignore_labels` pattern. Entities
+  carrying any of these labels and exceeding the threshold contribute
+  to a new penalty bucket. Zero false positives by design — the user
+  explicitly marks which sensors must keep reporting.
+
+**Why not auto-detect by device class:** Every commonly cited "safe"
+device class (`temperature`, `humidity`, `pressure`, `power`,
+`illuminance`, …) has legitimate long-quiet scenarios (climate-stable
+rooms, idle devices, nighttime). No single threshold works across
+them, and a magic default would violate the "no obfuscated thresholds"
+rule from `HAGHS_PHILOSOPHY.md`.
+
+**Technical primitive:** `state.last_reported` (HA Core 2024.4+).
+Updates on every backend message regardless of whether the value or
+attributes changed, so it survives Zigbee2MQTT's `force_update=False`
+default — which `state.last_updated` does not.
+
+**Prerequisite:** Bump `hacs.json` min HA version to ≥ 2024.4
+(already on the v2.3 pre-release checklist to raise to 2024.10+).
 
 ---
 
@@ -152,4 +183,4 @@ clickable links. This would require a feature request to HA Core.
 
 ---
 
-*Last updated: 2026-05-13*
+*Last updated: 2026-05-21*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,115 +1,91 @@
 # HAGHS Roadmap
 
-This document outlines planned features and improvements for the Home Assistant Global Health Score.
+This document outlines completed, planned, and declined features for the
+Home Assistant Global Health Score. It lives next to the active changelog
+(`v2.3_CHANGELOG.md`) and is refreshed whenever a release lands.
 
-## In Progress (dev branch)
+---
 
-### Power Supply Status Detection (#21)
+## Completed in v2.3 (dev branch)
 
-Auto-detect under-voltage conditions on Raspberry Pi devices via `binary_sensor.rpi_power_status`. A `Problem` state applies a flat 20-point penalty to the hardware score. No configuration needed — the check is skipped automatically on non-RPi hardware.
+All work below is committed on `dev` and described in detail in
+[`v2.3_CHANGELOG.md`](./v2.3_CHANGELOG.md).
 
-### Bug Fix: Unregistered Ghost Zombie Entities (#61)
+### Features
 
-**Problem:** Entities that exist in HA's state machine but have no entry in the entity registry are correctly detected as zombies but are completely invisible in the HA UI. Users cannot identify or resolve them, and there is no indication in the `zombie_entities` attribute that these entities are unregistered.
+- **Power Supply Status Detection (#21)** — Raspberry Pi under-voltage
+  auto-detection via `binary_sensor.rpi_power_status`, flat 20-point
+  penalty to the hardware score.
+- **Config Flow refactor + RepairsFlow (#49)** — CPU/RAM sensors optional
+  when PSI is available; coordinator split into `coordinator.py`; new
+  Repairs flow recovers from PSI disappearing post-setup.
+- **Pattern-based ignore (#64)** — `ignore_patterns` field accepts glob
+  patterns for entities without a unique ID (e.g. `monitor_docker`,
+  `torque`).
+- **Boolean recommendation flags** — Ten `rec_*` boolean state attributes
+  alongside the existing `recommendations` string, exported via
+  `REC_FLAG_KEYS`.
+- **PSI-aware recommendation text** — `REC_CPU_LOAD` and
+  `REC_RAM_PRESSURE` split into PSI / classic variants so the advisor
+  text makes the metric source explicit.
+- **7-day update grace period (#26)** — Pending updates only contribute
+  to the penalty after `UPDATE_GRACE_DAYS = 7`; pending list is
+  unaffected so users still see what is queued.
 
-**Solution:**
-- Mark unregistered zombie entities with an `[unregistered]` prefix in the `zombie_entities` attribute.
-- Emit a `WARNING` log entry so users can locate the entity ID via Settings > System > Logs.
+### Bug fixes
 
-**Scope:** `__init__.py` (`_calc_zombies()`). No attribute renames, no scoring changes.
+- **Hard cap at 99 while zombies exist (#61)** — `app_score` is capped at
+  99 whenever `zombie_count > 0` so the config-audit bonus cannot mask a
+  real zombie.
+- **Unregistered ghost zombies marked (#61)** — Entities without an
+  entity-registry entry are prepended with `[unregistered]` in the
+  `zombie_entities` attribute and warned in the log.
+- **Registry-race guard after restart (#62)** — Zombie detection is
+  deferred until `EVENT_HOMEASSISTANT_STARTED`, so labels are loaded
+  before the first scan.
+- **Restart grace via boot-time baseline (#27)** — `_calc_zombies` uses
+  `max(state.last_changed, boot_time)` so `last_changed` values restored
+  from the recorder no longer bypass the grace window.
+- **Battery-class extended grace (#62)** — `device_class=battery`
+  entities get a 60-minute grace window instead of 15 minutes.
+- **Denominator counts only `ZOMBIE_DOMAINS` (#9)** — `p_zombie` is no
+  longer diluted by automations, scripts, helpers, etc.
+- **Ignore label: `LabelSelector` (#30)** — Replaces the failing
+  `TextSelector` (special characters / case were silently ignored).
+- **Translation key alignment + Node.js 20 deprecation** — Fixed
+  hassfest after PR #49 adoption.
 
-### Bug Fix: Config Bonus Masking Zombie Penalty (#61)
+### Documentation
 
-**Problem:** The recorder configuration bonus (`config_bonus`, up to +10 pts) can fully negate the ratio-based zombie penalty on large instances. Result: a score of 100 is returned even when zombies are detected — violating the accuracy principle.
+- **External database walkthrough (#63)** — Full no-YAML SQL-sensor
+  setup with MariaDB query and Advanced Options.
+- **Setup paths corrected (#66)** — `Settings > Devices & Services > …`
+  everywhere.
+- **UI Integration clarification (#65)** — Card YAML must be added via
+  *Add Card → Manual*, plus a fix for the Lite card recommendations
+  block.
+- **Config-Audit tips in both cards (#67)** — Visual *Tips* block shows
+  which recorder bonus points are not yet earned.
+- **Pattern-Based Ignore documentation (#64)** — New README section
+  with glob examples.
+- **`rec_*` flags documented** — Added to the Sensor Attributes table.
 
-**Example:** 3 zombies / 300 total entities → p_zombie = 7 → app_score = min(100, 100 − 7 + 10) = 100.
+### Infrastructure
 
-**Solution:** Enforce a hard cap: when `zombie_count > 0`, `app_final` is capped at 99. Score 100 is only achievable with zero detected issues.
-
-**Scope:** `__init__.py` (`_async_calc_application()`). One additional line after the existing `app_final` calculation.
+- **Test bootstrap + migration coverage + pilot pillar (#54)** —
+  `tests/` directory, `pyproject.toml`, `requirements_test.txt`,
+  `.github/workflows/ci.yml`, plus the three phases of #54 (infra,
+  migration tests, `p_power` pilot pillar).
+- **`CONTRIBUTING.md` refresh** — Tests now mandatory, CI checks
+  documented, `vol.Exclusive("fixable")` trap noted.
 
 ---
 
 ## Planned
 
-### PSI-Aware Recommendation Text
-
-**Problem:** Two separate users confused PSI stall time with classic CPU utilization because the Advisor message `"CPU load is impacting score (6.5%)"` gives no indication that 6.5% refers to PSI stall time, not utilization percentage. Users who see 38% in System Monitor and 6.5% in the Advisor assume HAGHS is reacting to the wrong value.
-
-**Solution:** Split `REC_CPU_LOAD` in `_build_recommendations` into two context-aware variants:
-- PSI active: `"PSI CPU stall time is impacting score (X%)"` — makes the metric type explicit
-- Classic sensor: `"CPU utilization is impacting score (X%)"` — unchanged behavior
-
-Same pattern should be applied to the RAM and I/O recommendation strings for consistency.
-
-**Scope:** Backend only (`__init__.py` + `const.py` + `strings.json`). No scoring logic changes, no breaking changes to sensor attributes.
-
-### Smarter Zombie Grace Period for Battery-Class Sensors (#62)
-
-**Problem:** Battery sensors (`device_class: battery`) and operating voltage sensors
-(e.g., Homematic *Betriebsspannungspegel*) go `unavailable` when a Zigbee or Homematic
-coordinator restarts.
-
-Additionally, a user reported (2026-05-08) that battery sensors reappear in the zombie list after a full system restart even when the `haghs_ignore` label is correctly assigned. Likely cause: HAGHS evaluates zombie entities at startup before Home Assistant has fully loaded the entity registry, meaning labels are not yet available at the time of the first scan. This is a separate issue from the grace period fix.
-
-**Solution:** Apply a separate, extended grace period for entities with
-`device_class: battery` and measurement-type voltage sensors. Candidates:
-- Increase the grace period to 60 minutes for `device_class: battery` entities.
-
-**Scope:** `__init__.py` (`_calc_zombies()`). No attribute renames, no scoring formula
-changes.
-
-### Bug Fix: Denominator in `_calc_zombies`
-
-**Problem:** `hass.states.async_all()` returns all states, including `automation`, `script`, `person`, `zone`, `input_boolean` etc., which can never be zombies. The zombie detection only runs over `ZOMBIE_DOMAINS` (9 specific domains), but the total entity count used as the denominator includes all domains.
-
-**Result:** An artificially small ratio — an instance with many automations and few sensor entities is penalized far less for the same number of zombies compared to a pure sensor setup.
-
-**Solution:** Count only entities from `ZOMBIE_DOMAINS` as the denominator, consistent with zombie detection logic.
-
-**Scope:** `__init__.py` (`_calc_zombies()`).
-
-### Bug Fix: HA Restart and `last_changed` (Zombie Grace Period)
-
-**Problem:** After a HA restart, states are restored from the recorder database including their historical `last_changed` timestamp. An entity that was `unavailable` for 2 hours before shutdown will have `last_changed = "2+ hours ago"` after restart — HAGHS counts it as a zombie immediately instead of waiting for the 15-minute grace period.
-
-**Solution:** Apply an extended grace period after a HA restart, since `last_changed` timestamps restored from the database are historical and cannot be used as a reliable baseline.
-
-**Scope:** `__init__.py` (`_calc_zombies()`).
-
-### Recommendation Flags as Boolean Attributes
-
-**Problem:** Dashboard cards and external integrations must parse the `recommendations` string to react to specific advisor states. This is brittle and version-sensitive.
-
-**Solution:** Expose individual boolean attributes alongside the existing `recommendations` string:
-
-```
-rec_backup_stale: true
-rec_updates_pending: true
-rec_zombie: false
-```
-
-Cards and automations can check `state_attr(e, 'rec_backup_stale')` directly. Intended as the interface standard for all HA Pulse integrations.
-
-**Scope:** `__init__.py` + sensor attribute definitions. No changes to existing attributes.
-
-### Update Grace Period (7 Days)
-
-**Problem:** The `update_count` penalty deducts 5 points per pending update entity immediately when an update becomes available. This penalises normal user behaviour — most updates are installed within a few days — and causes score fluctuations that do not reflect a genuine health issue.
-
-**Solution:** Introduce a 7-day grace period for `update_count`. An update entity only contributes to the penalty if it has been in the `available` state for more than 7 days. This requires persisting the first-seen timestamp per update entity across coordinator runs (e.g., in `hass.data`). The `p_core_lag` penalty (20 pts for HA Core ≥ 3 minor versions behind) is unaffected.
-
-**Scope:** `__init__.py` (`_calc_updates()`). Persistent timestamp tracking in coordinator state. No changes to scoring formula, thresholds, or attributes.
-
-### Config Audit Bonus Visibility
-
-**Problem:** Users with a score below 100 and no active Advisor warnings have no way to understand why their score is not higher. The Advisor only flags active health issues, not missed bonus opportunities.
-
-**Example (#67):** Application score 90, no warnings. Cause: no entity filter active (missing +5), purge threshold possibly not met (missing +5). No explanation in the card.
-
-**Solution:** A separate "Tips" section in the dashboard card (visually distinct from warnings) that explains which Config Audit bonus points are not being earned. E.g.: "Enable entity filters in your recorder configuration to earn +5 bonus points."
-
-**Scope:** Dashboard card template only. No backend changes required.
+*No items currently queued for v2.4. Open issues are triaged on
+[GitHub](https://github.com/d-n91/home-assistant-global-health-score/issues)
+and added here once a concrete scope is agreed.*
 
 ---
 
@@ -119,14 +95,24 @@ Cards and automations can check `state_attr(e, 'rec_backup_stale')` directly. In
 
 **Status:** Will not be implemented.
 
-**Reasoning:** CPU temperature is a predictive hardware metric, not a current health indicator. If thermal throttling occurs, it already surfaces through elevated PSI stall values, which HAGHS captures. Adding temperature as a scoring component would dilute the existing hardware score without adding actionable health information. The required user configuration (sensor selection, threshold definition per hardware platform) conflicts with the pragmatism principle.
+**Reasoning:** CPU temperature is a predictive hardware metric, not a
+current health indicator. If thermal throttling occurs, it already
+surfaces through elevated PSI stall values, which HAGHS captures. Adding
+temperature as a scoring component would dilute the existing hardware
+score without adding actionable health information. The required user
+configuration (sensor selection, threshold definition per hardware
+platform) conflicts with the pragmatism principle.
 
 ### Check Entities URL Filtering
 
 **Status:** Not implementable within HAGHS.
 
-**Reasoning:** HA does not support URL-based filtering of the entity list by status. `/config/entities/edit/ENTITY_ID` is not a valid route. The `?domain=` URL parameter is ignored by HA's entity configuration page. Markdown links inside HTML `<summary>` tags are not rendered as clickable links. This would require a feature request to HA Core.
+**Reasoning:** HA does not support URL-based filtering of the entity
+list by status. `/config/entities/edit/ENTITY_ID` is not a valid route.
+The `?domain=` URL parameter is ignored by HA's entity configuration
+page. Markdown links inside HTML `<summary>` tags are not rendered as
+clickable links. This would require a feature request to HA Core.
 
 ---
 
-*Last updated: 2026-05-08*
+*Last updated: 2026-05-11*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,34 @@ All work below is committed on `dev` and described in detail in
 - **7-day update grace period (#26)** — Pending updates only contribute
   to the penalty after `UPDATE_GRACE_DAYS = 7`; pending list is
   unaffected so users still see what is queued.
+- **Multi-label ignore + dynamic toggling** — `ignore_labels` accepts
+  multiple labels. Inclusion/exclusion is toggled at runtime via HA's
+  native `label.assign` / `label.remove` service actions, so automations
+  can flip exclusions (e.g. a `vacation` label) without reloading the
+  integration. Migration `(3,2)→(3,3)` converts the legacy single-label
+  setting transparently.
+- **Disabled-entity auto-ignore** — Entities marked
+  `disabled_by != None` in the entity registry are excluded from zombie
+  detection and update penalties without requiring a label. Removes the
+  community-flagged friction of having to label every disabled entity.
+- **ZOMBIE_DOMAINS expansion (9 → 22) + per-domain breakdown + cap
+  raise** — Scoring scope expanded to 22 physical/UI-relevant domains
+  (`alarm_control_panel`, `camera`, `climate`, `cover`,
+  `device_tracker`, `fan`, `humidifier`, `lawn_mower`, `light`, `lock`,
+  `media_player`, `number`, `remote`, `select`, `siren`, `switch`,
+  `text`, `vacuum`, `valve`, `water_heater` added; `button` / `event`
+  deliberately excluded — their default `unknown` would cause false
+  positives). New `zombie_count_per_domain` attribute exposes a
+  per-domain dict; `ZOMBIE_LIST_CAP` raised from 20 → 100 entries (the
+  count and per-domain map always carry full totals regardless of the
+  display cap).
+- **Configurable zombie + battery grace periods** — Two new Options
+  Flow fields: `zombie_grace_minutes` (1–240, default 15) and
+  `battery_grace_minutes` (1–240, default 60). Both periods are
+  independent (battery grace can be set below the general grace — this
+  intentionally disables the extension). Replaces the previous
+  hard-coded `ZOMBIE_GRACE_SECONDS` / `BATTERY_GRACE_SECONDS`
+  constants.
 
 ### Bug fixes
 
@@ -54,6 +82,15 @@ All work below is committed on `dev` and described in detail in
   `TextSelector` (special characters / case were silently ignored).
 - **Translation key alignment + Node.js 20 deprecation** — Fixed
   hassfest after PR #49 adoption.
+- **Pro-card improvements bundle** — Pending-updates list now renders
+  one item per line with a bullet prefix; zombie list separates tracked
+  entities (run through `expand()` for friendly names) from
+  `[unregistered]` ghosts (rendered as a separate `<details>` block so
+  ghost markers no longer get silently dropped); per-domain summary
+  reads from the new `zombie_count_per_domain` attribute with a
+  namespace-loop fallback for users still on v2.2.2; cap message
+  rewritten to use `z_count > z_list | length` instead of a hard-coded
+  "first 100".
 
 ### Documentation
 
@@ -115,4 +152,4 @@ clickable links. This would require a feature request to HA Core.
 
 ---
 
-*Last updated: 2026-05-11*
+*Last updated: 2026-05-13*

--- a/custom_components/haghs/__init__.py
+++ b/custom_components/haghs/__init__.py
@@ -33,9 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     config = {**entry.data, **entry.options}
     psi = await hass.async_add_executor_job(HaghsDataUpdateCoordinator._read_psi_sync)
-    if not psi.available and not (
-        CONF_CPU_SENSOR in config and CONF_RAM_SENSOR in config
-    ):
+    if not psi.available and not (CONF_CPU_SENSOR in config and CONF_RAM_SENSOR in config):
         ir.async_create_issue(
             hass,
             DOMAIN,

--- a/custom_components/haghs/__init__.py
+++ b/custom_components/haghs/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     _CONFIG_VERSION,
     CONF_CPU_SENSOR,
     CONF_IGNORE_LABEL,
+    CONF_IGNORE_LABELS,
     CONF_RAM_SENSOR,
     DOMAIN,
     IssueIds,
@@ -82,8 +83,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     Migration steps so far:
       <= (3, 2): convert legacy text ignore-label values into label IDs.
-      (3, 3):    no data change, only a version bump for the new ignore
-                 patterns option, which is backward-compatible.
+      <= (3, 3): convert the single CONF_IGNORE_LABEL into the new
+                 CONF_IGNORE_LABELS list (one-element list when the legacy
+                 key holds a value, removed entirely when empty).
+      (3, 4):    current version, no further data shape changes.
     """
     entry_version = VersionInformation(major=entry.version, minor=entry.minor_version)
 
@@ -104,6 +107,11 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _migrate_ignore_label_value(label_registry, data)
         _migrate_ignore_label_value(label_registry, options)
 
+    labels_list_version = VersionInformation(major=3, minor=3)
+    if entry_version <= labels_list_version:
+        _migrate_label_to_labels(data)
+        _migrate_label_to_labels(options)
+
     hass.config_entries.async_update_entry(
         entry,
         data=data,
@@ -113,6 +121,25 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     _LOGGER.info("HAGHS migrated to version %s", _CONFIG_VERSION)
+    return True
+
+
+def _migrate_label_to_labels(config: dict[str, Any]) -> bool:
+    """Promote a single CONF_IGNORE_LABEL value into the CONF_IGNORE_LABELS list.
+
+    Idempotent: if the legacy key is absent the function is a no-op. If both
+    keys coexist (should not happen, but defensive), the legacy value is
+    merged into the list without duplicating.
+    """
+    legacy = config.pop(CONF_IGNORE_LABEL, None)
+    if not legacy:
+        return False
+
+    existing = config.get(CONF_IGNORE_LABELS, [])
+    if legacy in existing:
+        return True
+
+    config[CONF_IGNORE_LABELS] = [legacy, *existing]
     return True
 
 

--- a/custom_components/haghs/__init__.py
+++ b/custom_components/haghs/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import (
 )
 
 from .const import (
+    _CONFIG_VERSION,
     CONF_CPU_SENSOR,
     CONF_IGNORE_LABEL,
     CONF_RAM_SENSOR,
@@ -77,10 +78,22 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Migrate old entry."""
+    """Migrate old entry to the current _CONFIG_VERSION.
+
+    Migration steps so far:
+      <= (3, 2): convert legacy text ignore-label values into label IDs.
+      (3, 3):    no data change, only a version bump for the new ignore
+                 patterns option, which is backward-compatible.
+    """
     entry_version = VersionInformation(major=entry.version, minor=entry.minor_version)
 
-    _LOGGER.info("Migrating configuration from version %s", entry_version)
+    if entry_version >= _CONFIG_VERSION:
+        return True
+
+    _LOGGER.info("Migrating HAGHS configuration from version %s", entry_version)
+
+    data = dict(entry.data)
+    options = dict(entry.options)
 
     label_change_version = VersionInformation(major=3, minor=2)
     if entry_version <= label_change_version:
@@ -88,24 +101,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await lr.async_load(hass)
 
         label_registry = lr.async_get(hass)
+        _migrate_ignore_label_value(label_registry, data)
+        _migrate_ignore_label_value(label_registry, options)
 
-        data = dict(entry.data)
-        options = dict(entry.options)
-        data_changed = _migrate_ignore_label_value(label_registry, data)
-        options_changed = _migrate_ignore_label_value(label_registry, options)
+    hass.config_entries.async_update_entry(
+        entry,
+        data=data,
+        options=options,
+        version=_CONFIG_VERSION.major,
+        minor_version=_CONFIG_VERSION.minor,
+    )
 
-        if data_changed or options_changed:
-            _LOGGER.info("HAGHS: Migrated ignore label to label ID")
-
-        hass.config_entries.async_update_entry(
-            entry,
-            data=data,
-            options=options,
-            version=label_change_version.major,
-            minor_version=label_change_version.minor,
-        )
-
-    _LOGGER.info("Migration to version %s successful", entry_version)
+    _LOGGER.info("HAGHS migrated to version %s", _CONFIG_VERSION)
     return True
 
 

--- a/custom_components/haghs/__init__.py
+++ b/custom_components/haghs/__init__.py
@@ -1,901 +1,58 @@
 """The HAGHS integration."""
+
 from __future__ import annotations
 
-import asyncio
 import logging
-import math
-import os
-import re
-from dataclasses import dataclass, field
-from datetime import timedelta
 from typing import Any
 
-import psutil
-
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util import dt as dt_util
+from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers import (
+    label_registry as lr,
+)
 
 from .const import (
     CONF_CPU_SENSOR,
-    CONF_DB_SENSOR,
     CONF_IGNORE_LABEL,
     CONF_RAM_SENSOR,
-    CONF_STORAGE_TYPE,
-    CONF_UPDATE_INTERVAL,
-    DEFAULT_STORAGE_TYPE,
-    DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
-    REC_ALL_CLEAR,
-    REC_BACKUP_STALE,
-    REC_CORE_LAG,
-    REC_CPU_LOAD,
-    REC_DB_OVER_LIMIT,
-    REC_DISK_SD_LOW,
-    REC_DISK_SSD_LOW,
-    REC_IO_PRESSURE,
-    REC_POWER_UNSTABLE,
-    REC_RAM_PRESSURE,
-    REC_UPDATES_PENDING,
-    REC_ZOMBIES,
+    IssueIds,
+    VersionInformation,
 )
+from .coordinator import HaghsDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[str] = ["sensor"]
 
-# Size constants
-_GB = 1024**3
-
-# Timeout for each scoring sub-calculation (seconds).
-PILLAR_TIMEOUT: float = 10.0
-
-# Default HA SQLite database filename
-HA_DB_NAME = "home-assistant_v2.db"
-
-# PSI (Pressure Stall Information) paths — Linux only
-PSI_CPU_PATH = "/proc/pressure/cpu"
-PSI_MEMORY_PATH = "/proc/pressure/memory"
-PSI_IO_PATH = "/proc/pressure/io"
-
-# Regex to extract 'some avg10=X.XX' from PSI files
-_PSI_SOME_AVG10_RE = re.compile(r"some\s+avg10=(\d+\.?\d*)")
-
-# Domains to check for zombie entities
-ZOMBIE_DOMAINS: frozenset[str] = frozenset(
-    [
-        "sensor",
-        "binary_sensor",
-        "switch",
-        "light",
-        "fan",
-        "climate",
-        "media_player",
-        "vacuum",
-        "camera",
-    ]
-)
-
-
-@dataclass
-class _PsiData:
-    """Pressure Stall Information (some avg10 values).
-
-    None means the file could not be read (unsupported platform / old kernel).
-    """
-
-    cpu: float | None = None
-    memory: float | None = None
-    io: float | None = None
-
-    @property
-    def available(self) -> bool:
-        """Return True if at least CPU and memory PSI data was read."""
-        return self.cpu is not None and self.memory is not None
-
-
-@dataclass
-class _HardwareResult:
-    """Result of the hardware pillar calculation."""
-
-    hardware_score: float = 100.0
-    cpu: float = 0.0
-    ram: float = 0.0
-    io: float = 0.0
-    disk: float = 0.0
-    disk_total: int = 0
-    disk_free: int = 0
-    p_cpu: int = 0
-    p_ram: int = 0
-    p_io: int = 0
-    p_power: int = 0
-    psi_available: bool = False
-
-
-@dataclass
-class _ApplicationResult:
-    """Result of the application pillar calculation."""
-
-    app_score: int = 100
-    zombie_count: int = 0
-    zombie_list: list[str] = field(default_factory=list)
-    db_mb: float = 0.0
-    db_limit_mb: float = 1000.0
-    update_count: int = 0
-    pending_updates: list[str] = field(default_factory=list)
-    config_bonus: int = 0
-    p_backup: int = 0
-    p_core_lag: int = 0
-    p_zombie: int = 0
-
-
-@dataclass
-class _RecorderInfo:
-    """Recorder configuration data — prepared for Phase 3 scoring."""
-
-    keep_days: int | None = None
-    entity_filter_active: bool = False
-    available: bool = False
-
-
-class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Coordinator that calculates the Global Health Score."""
-
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize the coordinator."""
-        # Options take priority over data for runtime-configurable fields
-        opts: dict = {**entry.data, **entry.options}
-
-        interval_sec = int(opts.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=DOMAIN,
-            update_interval=timedelta(seconds=interval_sec),
-        )
-        self.cpu_id: str | None = opts.get(CONF_CPU_SENSOR)
-        self.ram_id: str | None = opts.get(CONF_RAM_SENSOR)
-        self.db_sensor_id: str | None = opts.get(CONF_DB_SENSOR) or None
-        self.ignore_label: str | None = opts.get(CONF_IGNORE_LABEL)
-        self._storage_type: str = opts.get(CONF_STORAGE_TYPE, DEFAULT_STORAGE_TYPE)
-
-        # Paths for auto-detection (resolved once at init)
-        self._db_path: str = hass.config.path(HA_DB_NAME)
-        self._config_dir: str = hass.config.config_dir
-
-        # Recorder info — populated on each update cycle (Phase 3 ready)
-        self.recorder_info: _RecorderInfo = _RecorderInfo()
-
-    # ------------------------------------------------------------------
-    # Main update — orchestrates sub-calculations with safety net
-    # ------------------------------------------------------------------
-
-    async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch data and calculate the health score.
-
-        Each pillar runs in its own guarded coroutine.  On timeout or
-        exception the affected pillar falls back to a neutral score
-        (100 / no penalty) and a warning is logged.  The coordinator
-        itself never crashes.
-        """
-        # Recorder info — read before app pillar so config audit can use it
-        self.recorder_info = self._read_recorder_info()
-
-        hw = await self._safe_calc(
-            "hardware",
-            self._async_calc_hardware(),
-            _HardwareResult(),
-        )
-
-        app = await self._safe_calc(
-            "application",
-            self._async_calc_application(),
-            _ApplicationResult(),
-        )
-
-        global_score = max(0, min(100, math.floor(
-            (hw.hardware_score * 0.4) + (app.app_score * 0.6)
-        )))
-
-        advice = self._build_recommendations(hw, app)
-
-        return {
-            "global_score": int(global_score),
-            "hardware_score": int(hw.hardware_score),
-            "application_score": app.app_score,
-            "zombie_count": app.zombie_count,
-            "zombie_entities": app.zombie_list,
-            "db_size_mb": round(app.db_mb, 1),
-            "psi_available": hw.psi_available,
-            "recorder_keep_days": self.recorder_info.keep_days,
-            "recorder_filter_active": self.recorder_info.entity_filter_active,
-            "pending_updates": app.pending_updates,
-            "recommendations": (
-                "\n".join(advice) if advice else REC_ALL_CLEAR
-            ),
-        }
-
-    async def _safe_calc(
-        self,
-        name: str,
-        coro: Any,
-        fallback: Any,
-    ) -> Any:
-        """Run *coro* with a timeout; return *fallback* on any failure."""
-        try:
-            return await asyncio.wait_for(coro, timeout=PILLAR_TIMEOUT)
-        except TimeoutError:
-            _LOGGER.warning(
-                "HAGHS: %s calculation timed out after %ss — using neutral score",
-                name,
-                PILLAR_TIMEOUT,
-            )
-            return fallback
-        except Exception:
-            _LOGGER.warning(
-                "HAGHS: %s calculation failed — using neutral score",
-                name,
-                exc_info=True,
-            )
-            return fallback
-
-    # ------------------------------------------------------------------
-    # PSI (Pressure Stall Information) reader
-    # ------------------------------------------------------------------
-
-    async def _async_read_psi(self) -> _PsiData:
-        """Read Linux PSI data from /proc/pressure via executor.
-
-        Returns _PsiData with None fields for any file that cannot be read
-        (Windows, old kernels, containers without /proc mounted).
-        """
-        return await self.hass.async_add_executor_job(self._read_psi_sync)
-
-    @staticmethod
-    def _read_psi_sync() -> _PsiData:
-        """Synchronous PSI reader — runs in the executor thread pool."""
-        return _PsiData(
-            cpu=HaghsDataUpdateCoordinator._parse_psi_file(PSI_CPU_PATH),
-            memory=HaghsDataUpdateCoordinator._parse_psi_file(PSI_MEMORY_PATH),
-            io=HaghsDataUpdateCoordinator._parse_psi_file(PSI_IO_PATH),
-        )
-
-    @staticmethod
-    def _parse_psi_file(path: str) -> float | None:
-        """Parse 'some avg10' from a single PSI file.  Returns None on failure."""
-        try:
-            with open(path, encoding="utf-8") as fh:
-                content = fh.read()
-            match = _PSI_SOME_AVG10_RE.search(content)
-            if match:
-                return float(match.group(1))
-            return None
-        except (OSError, ValueError):
-            return None
-
-    # ------------------------------------------------------------------
-    # Hardware pillar (40 %)
-    # ------------------------------------------------------------------
-
-    async def _async_calc_hardware(self) -> _HardwareResult:
-        """Calculate the hardware pillar score.
-
-        Data sources — with smart fallback:
-          CPU:  PSI /proc/pressure/cpu some avg10  → fallback: CONF_CPU_SENSOR
-          RAM:  PSI /proc/pressure/memory some avg10  → fallback: CONF_RAM_SENSOR
-          I/O:  PSI /proc/pressure/io some avg10  (PSI-only, no fallback)
-          Disk: psutil.disk_usage (always auto-detected)
-
-        PSI values measure stall time (% of time tasks waited for a resource).
-        Classic sensor values measure utilization (% of resource in use).
-        These require separate threshold tiers because their scales differ
-        fundamentally.
-        """
-        # Try PSI first (non-blocking via executor)
-        psi = await self._async_read_psi()
-        use_psi = psi.available
-
-        # -- CPU --
-        if psi.cpu is not None:
-            cpu = psi.cpu
-            p_cpu = self._psi_cpu_penalty(cpu)
-        else:
-            cpu = self._get_float(self.cpu_id)
-            if cpu > 100:
-                _LOGGER.warning(
-                    "HAGHS: CPU sensor '%s' returned %.1f — expected 0-100%%. "
-                    "Please select a sensor that reports CPU usage in percent",
-                    self.cpu_id,
-                    cpu,
-                )
-                cpu = min(cpu, 100.0)
-            p_cpu = self._classic_cpu_penalty(cpu)
-        score_cpu = 100 - p_cpu
-
-        # -- RAM --
-        if psi.memory is not None:
-            ram = psi.memory
-            p_ram = self._psi_memory_penalty(ram)
-        else:
-            ram = self._get_float(self.ram_id)
-            if ram > 100:
-                _LOGGER.warning(
-                    "HAGHS: RAM sensor '%s' returned %.1f — expected 0-100%%. "
-                    "Please select a sensor that reports memory usage in percent",
-                    self.ram_id,
-                    ram,
-                )
-                ram = min(ram, 100.0)
-            p_ram = self._classic_ram_penalty(ram)
-        score_ram = 100 - p_ram
-
-        # -- I/O (PSI-only — no classic fallback) --
-        io_val = psi.io if psi.io is not None else 0.0
-        p_io = 0
-        if psi.io is not None:
-            p_io = self._psi_io_penalty(psi.io)
-        score_io = 100 - p_io
-
-        # -- Disk: always auto-detected via psutil — smart thresholds --
-        disk_usage = await self._async_get_disk_usage()
-        if disk_usage is not None:
-            disk_total = disk_usage.total
-            disk_free = disk_usage.free
-            disk_pct = disk_usage.percent
-
-            if self._storage_type in ("sd-card", "emmc"):
-                # SD-Card / eMMC logic: critical < 3 GB free, warning < 5 GB free
-                if disk_free < 3 * _GB:
-                    score_disk = 0.0
-                elif disk_free < 5 * _GB:
-                    score_disk = 50.0
-                else:
-                    score_disk = 100.0
-            else:
-                # SSD logic: warning < 10% free
-                free_pct = (disk_free / disk_total) * 100 if disk_total > 0 else 100
-                if free_pct < 10:
-                    score_disk = max(0.0, free_pct * 10)
-                else:
-                    score_disk = 100.0
-        else:
-            disk_total = 0
-            disk_free = 0
-            disk_pct = 0.0
-            score_disk = 100.0
-
-        # -- Power Supply (RPi auto-detection) --
-        p_power = 0
-        power_state = self.hass.states.get("binary_sensor.rpi_power_status")
-        if power_state and power_state.state == "on":
-            p_power = 20
-
-        # -- Final hardware score --
-        # When PSI I/O is available: 4 components (CPU, RAM, I/O, Disk)
-        # When I/O is not available: 3 components (CPU, RAM, Disk)
-        # Power penalty is applied as a flat deduction (not averaged)
-        if psi.io is not None:
-            hardware_final = max(
-                0.0,
-                min(100.0, (score_cpu + score_ram + score_io + score_disk) / 4
-                    - p_power),
-            )
-        else:
-            hardware_final = max(
-                0.0,
-                min(100.0, (score_cpu + score_ram + score_disk) / 3
-                    - p_power),
-            )
-
-        if use_psi:
-            _LOGGER.debug(
-                "HAGHS: Using PSI data — cpu=%.2f memory=%.2f io=%s",
-                psi.cpu,
-                psi.memory,
-                psi.io,
-            )
-        else:
-            _LOGGER.debug("HAGHS: PSI not available — using sensor fallback")
-
-        return _HardwareResult(
-            hardware_score=hardware_final,
-            cpu=cpu,
-            ram=ram,
-            io=io_val,
-            disk=disk_pct,
-            disk_total=disk_total,
-            disk_free=disk_free,
-            p_cpu=p_cpu,
-            p_ram=p_ram,
-            p_io=p_io,
-            p_power=p_power,
-            psi_available=use_psi,
-        )
-
-    # -- CPU penalty tiers -------------------------------------------------
-
-    @staticmethod
-    def _classic_cpu_penalty(cpu: float) -> int:
-        """Tiered penalty for classic CPU usage sensor (utilization %).
-
-        Classic sensors report how busy the CPU is.  25% is normal for an
-        active system, so penalties only start above that threshold.
-        """
-        if cpu <= 25:
-            return 0
-        if cpu <= 40:
-            return 10
-        if cpu <= 60:
-            return 25
-        if cpu <= 80:
-            return 50
-        return 80
-
-    @staticmethod
-    def _psi_cpu_penalty(psi_val: float) -> int:
-        """Tiered penalty for PSI CPU pressure (stall time %).
-
-        PSI measures how long tasks waited for CPU.  Even 5% stall time
-        is noticeable — automation latency increases measurably.
-        """
-        if psi_val <= 5:
-            return 0
-        if psi_val <= 15:
-            return 10
-        if psi_val <= 30:
-            return 25
-        if psi_val <= 50:
-            return 50
-        return 80
-
-    # -- RAM penalty tiers -------------------------------------------------
-
-    @staticmethod
-    def _classic_ram_penalty(ram: float) -> int:
-        """Tiered penalty for classic RAM usage sensor (utilization %).
-
-        HA + Supervisor typically consume 60-70% of RAM.  Penalties start
-        at 70% with a linear ramp to leave headroom for spikes.
-        """
-        if ram < 70:
-            return 0
-        if ram < 80:
-            return int((ram - 70) * 3.33)  # 0 → 33
-        if ram < 90:
-            return int(33 + (ram - 80) * 3.37)  # 33 → 67
-        return 80
-
-    @staticmethod
-    def _psi_memory_penalty(psi_val: float) -> int:
-        """Tiered penalty for PSI memory pressure (stall time %).
-
-        Memory stalls are more critical than CPU stalls because they can
-        trigger the OOM killer.  Thresholds are tighter than CPU.
-        """
-        if psi_val <= 5:
-            return 0
-        if psi_val <= 10:
-            return 10
-        if psi_val <= 25:
-            return 25
-        if psi_val <= 40:
-            return 50
-        return 80
-
-    # -- I/O penalty tiers -------------------------------------------------
-
-    @staticmethod
-    def _psi_io_penalty(psi_val: float) -> int:
-        """Tiered penalty for PSI I/O pressure (stall time %).
-
-        I/O stalls directly affect recorder writes, automation execution,
-        and restart times.  Thresholds match CPU PSI.
-        """
-        if psi_val <= 5:
-            return 0
-        if psi_val <= 15:
-            return 10
-        if psi_val <= 30:
-            return 25
-        if psi_val <= 50:
-            return 50
-        return 80
-
-    async def _async_get_disk_usage(self) -> Any | None:
-        """Return full psutil disk_usage result, or None on failure."""
-        try:
-            return await self.hass.async_add_executor_job(
-                psutil.disk_usage, self._config_dir
-            )
-        except (OSError, FileNotFoundError):
-            _LOGGER.warning(
-                "HAGHS: Could not read disk usage for %s — assuming healthy",
-                self._config_dir,
-            )
-            return None
-
-    # ------------------------------------------------------------------
-    # Application pillar (60 %)
-    # ------------------------------------------------------------------
-
-    async def _async_calc_application(self) -> _ApplicationResult:
-        """Calculate the application pillar score."""
-        # A. ZOMBIES
-        zombie_list, p_zombie, zombie_count = self._calc_zombies()
-
-        # B. INTEGRATION HEALTH
-        p_integration = self._calc_integration_health()
-
-        # C. MAINTENANCE — DB size auto-detected (blocking I/O → executor)
-        db_mb, p_db, db_limit_mb = await self._async_calc_maintenance()
-
-        # D. UPDATES
-        p_backup, update_count, p_updates, p_core_lag, pending_updates = (
-            self._calc_updates()
-        )
-
-        # E. CONFIG AUDIT — bonus for good recorder configuration
-        config_bonus = self._calc_config_audit()
-
-        app_final = max(
-            0,
-            min(
-                100,
-                100 - p_zombie - p_integration - p_backup - p_updates - p_db
-                + config_bonus,
-            ),
-        )
-
-        return _ApplicationResult(
-            app_score=app_final,
-            zombie_count=zombie_count,
-            zombie_list=zombie_list,
-            db_mb=db_mb,
-            db_limit_mb=db_limit_mb,
-            update_count=update_count,
-            pending_updates=pending_updates,
-            config_bonus=config_bonus,
-            p_backup=p_backup,
-            p_core_lag=p_core_lag,
-            p_zombie=p_zombie,
-        )
-
-    # ------------------------------------------------------------------
-    # Application sub-calculations
-    # ------------------------------------------------------------------
-
-    def _calc_zombies(self) -> tuple[list[str], int, int]:
-        """Detect zombie entities, respecting ignore labels and grace period.
-
-        Returns (zombie_list_capped, p_zombie, zombie_count).
-        zombie_list is capped to 20 entries for state attributes;
-        zombie_count always reflects the full number.
-        """
-        ent_reg = er.async_get(self.hass)
-        dev_reg = dr.async_get(self.hass)
-        now = dt_util.utcnow()
-        zombie_list: list[str] = []
-
-        for state in self.hass.states.async_all():
-            if state.domain not in ZOMBIE_DOMAINS:
-                continue
-            if state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-                continue
-
-            # Grace period: skip entities that changed < 15 min ago
-            if (now - state.last_changed).total_seconds() < 900:
-                continue
-
-            entity_id = state.entity_id
-            if "integration_health" in entity_id:
-                continue
-
-            is_ignored = False
-            entity_entry = ent_reg.async_get(entity_id)
-            if entity_entry and self.ignore_label in (
-                entity_entry.labels or set()
-            ):
-                is_ignored = True
-
-            if not is_ignored and entity_entry and entity_entry.device_id:
-                device_entry = dev_reg.async_get(entity_entry.device_id)
-                if device_entry and self.ignore_label in (
-                    device_entry.labels or set()
-                ):
-                    is_ignored = True
-
-            if not is_ignored:
-                zombie_list.append(entity_id)
-
-        zombie_count = len(zombie_list)
-
-        # Ratio-based penalty: percentage of zombies relative to total entities
-        # Factor 7 + ceil ensures zombies are visible on all instance sizes
-        total_entities = len(self.hass.states.async_all())
-        if total_entities > 0:
-            zombie_ratio_pct = (zombie_count / total_entities) * 100
-            p_zombie = min(20, math.ceil(zombie_ratio_pct * 7))
-        else:
-            p_zombie = 0
-
-        # Cap the list for state attributes (count stays full)
-        return zombie_list[:20], p_zombie, zombie_count
-
-    def _calc_integration_health(self) -> int:
-        """Count unhealthy integrations via native ConfigEntry states.
-
-        Checks for integrations stuck in SETUP_ERROR, SETUP_RETRY, or
-        FAILED_UNLOAD — the same states HA shows as "error" in the UI.
-        Penalty: 5 pts per unhealthy integration, capped at 15.
-        """
-        unhealthy_states = {
-            ConfigEntryState.SETUP_ERROR,
-            ConfigEntryState.SETUP_RETRY,
-            ConfigEntryState.FAILED_UNLOAD,
-        }
-        failed = sum(
-            1
-            for entry in self.hass.config_entries.async_entries()
-            if entry.state in unhealthy_states
-        )
-        return min(15, failed * 5)
-
-    async def _async_calc_maintenance(self) -> tuple[float, int, float]:
-        """Calculate DB penalty with dynamic limit based on entity count."""
-        db_mb = await self._async_get_db_size_mb()
-        total_entities = len(self.hass.states.async_all())
-        db_limit_mb = 1000 + (total_entities * 2.5)
-
-        p_db = 0
-        if db_mb < db_limit_mb:
-            p_db = 0
-        elif db_mb < db_limit_mb * 2.5:
-            p_db = 10
-        else:
-            p_db = 30
-
-        return db_mb, p_db, db_limit_mb
-
-    async def _async_get_db_size_mb(self) -> float:
-        """Return the HA database size in MB.
-
-        If an external DB sensor is configured, its state is used directly
-        (expected to report size in MB).  Otherwise falls back to measuring
-        the local SQLite file via os.path.getsize.
-        Returns 0.0 if no measurement is available (external DB without
-        sensor, or missing SQLite file).
-        """
-        # External DB sensor override
-        if self.db_sensor_id:
-            val = self._get_float(self.db_sensor_id)
-            if val > 0:
-                _LOGGER.debug(
-                    "HAGHS: Using external DB sensor '%s' — %.1f MB",
-                    self.db_sensor_id,
-                    val,
-                )
-                return val
-            _LOGGER.debug(
-                "HAGHS: External DB sensor '%s' returned %.1f — "
-                "skipping DB penalty",
-                self.db_sensor_id,
-                val,
-            )
-            return 0.0
-
-        # Default: local SQLite file
-        try:
-            size_bytes: int = await self.hass.async_add_executor_job(
-                os.path.getsize, self._db_path
-            )
-            return size_bytes / (1024 * 1024)
-        except OSError:
-            _LOGGER.debug(
-                "HAGHS: SQLite DB not found at %s — assuming external database",
-                self._db_path,
-            )
-            return 0.0
-
-    def _calc_updates(self) -> tuple[int, int, int, int, list[str]]:
-        """Calculate backup, update and core-lag penalties.
-
-        Returns (p_backup, update_count, p_updates, p_core_lag, pending_updates).
-        Update entities with the ignore label are excluded from counting and penalties.
-        Core lag threshold: >= 3 months behind.
-        """
-        backup_state = self.hass.states.get("binary_sensor.backups_stale")
-        p_backup = 30 if (backup_state and backup_state.state == "on") else 0
-
-        ent_reg = er.async_get(self.hass)
-        update_count = 0
-        pending_updates: list[str] = []
-
-        for state in self.hass.states.async_all():
-            if state.domain == "update" and state.state == "on":
-                # Check ignore label on update entity
-                entity_entry = ent_reg.async_get(state.entity_id)
-                if entity_entry and self.ignore_label in (
-                    entity_entry.labels or set()
-                ):
-                    continue
-                update_count += 1
-                name = state.attributes.get("friendly_name", state.entity_id)
-                pending_updates.append(name)
-
-        p_core_lag = 0
-        core_entity_id = self._detect_core_update_entity()
-        core_state = self.hass.states.get(core_entity_id) if core_entity_id else None
-        if core_state:
-            current: str | None = core_state.attributes.get("installed_version")
-            latest: str | None = core_state.attributes.get("latest_version")
-            if current and latest and "." in current and "." in latest:
-                try:
-                    cur_parts = [int(x) for x in current.split(".")[:2]]
-                    lat_parts = [int(x) for x in latest.split(".")[:2]]
-                    if (
-                        (lat_parts[0] * 12) + lat_parts[1]
-                    ) - ((cur_parts[0] * 12) + cur_parts[1]) >= 3:
-                        p_core_lag = 20
-                except (ValueError, IndexError):
-                    pass
-
-        p_updates = min(35, (update_count * 5) + p_core_lag)
-        return p_backup, update_count, p_updates, p_core_lag, pending_updates
-
-    # ------------------------------------------------------------------
-    # Config Audit — bonus for good recorder configuration
-    # ------------------------------------------------------------------
-
-    def _calc_config_audit(self) -> int:
-        """Calculate config audit bonus based on recorder configuration.
-
-        Awards bonus points (reduces net penalty) for good practices:
-          +5  if purge_keep_days is configured
-          +5  if include/exclude entity filter is active
-        Max bonus: 10.
-        """
-        bonus = 0
-        if self.recorder_info.available:
-            if self.recorder_info.keep_days is not None:
-                bonus += 5
-            if self.recorder_info.entity_filter_active:
-                bonus += 5
-        return bonus
-
-    # ------------------------------------------------------------------
-    # Recorder info reader
-    # ------------------------------------------------------------------
-
-    def _read_recorder_info(self) -> _RecorderInfo:
-        """Read recorder configuration from hass.data.
-
-        Safe access — returns empty _RecorderInfo if recorder is not loaded
-        or not available (e.g. external database without recorder component).
-        """
-        try:
-            recorder = self.hass.data.get("recorder_instance")
-            if recorder is None:
-                _LOGGER.debug("HAGHS: Recorder instance not found in hass.data")
-                return _RecorderInfo()
-
-            keep_days = getattr(recorder, "keep_days", None)
-            entity_filter = getattr(recorder, "entity_filter", None)
-
-            return _RecorderInfo(
-                keep_days=keep_days,
-                entity_filter_active=entity_filter is not None,
-                available=True,
-            )
-        except Exception:
-            _LOGGER.warning(
-                "HAGHS: Failed to read recorder info — skipping",
-                exc_info=True,
-            )
-            return _RecorderInfo()
-
-    # ------------------------------------------------------------------
-    # Dynamic core update entity detection
-    # ------------------------------------------------------------------
-
-    def _detect_core_update_entity(self) -> str | None:
-        """Dynamically find the HA Core update entity.
-
-        Searches the update domain for an entity that represents
-        Home Assistant Core.  Works across Supervised, Docker, and K8s setups.
-
-        Detection strategy (first match wins):
-          1. entity_id contains 'home_assistant_core'
-          2. title attribute contains 'Home Assistant Core' (case-insensitive)
-        """
-        for state in self.hass.states.async_all("update"):
-            eid = state.entity_id
-            if "home_assistant_core" in eid:
-                return eid
-            title = state.attributes.get("title", "")
-            if title and "home assistant core" in title.lower():
-                return eid
-        _LOGGER.debug("HAGHS: No HA Core update entity found — core lag check skipped")
-        return None
-
-    # ------------------------------------------------------------------
-    # Recommendations builder
-    # ------------------------------------------------------------------
-
-    def _build_recommendations(
-        self,
-        hw: _HardwareResult,
-        app: _ApplicationResult,
-    ) -> list[str]:
-        """Build human-readable recommendation strings.
-
-        All templates are defined in const.py (mirrored in strings.json)
-        so translators can find and override them.
-        """
-        advice: list[str] = []
-        if hw.p_cpu > 0:
-            advice.append(REC_CPU_LOAD.format(cpu_pct=hw.cpu))
-        if hw.p_ram > 0:
-            advice.append(REC_RAM_PRESSURE.format(ram_pct=hw.ram))
-        if hw.p_io > 0:
-            advice.append(REC_IO_PRESSURE.format(io_pct=hw.io))
-        if (
-            self._storage_type in ("sd-card", "emmc")
-            and hw.disk_free < 5 * _GB
-            and hw.disk_total > 0
-        ):
-            advice.append(
-                REC_DISK_SD_LOW.format(
-                    free_gb=hw.disk_free / _GB,
-                    storage_type=self._storage_type,
-                )
-            )
-        elif self._storage_type == "ssd" and hw.disk_total > 0:
-            free_pct = (hw.disk_free / hw.disk_total) * 100
-            if free_pct < 10:
-                advice.append(
-                    REC_DISK_SSD_LOW.format(free_gb=hw.disk_free / _GB)
-                )
-        if app.db_mb > app.db_limit_mb:
-            advice.append(
-                REC_DB_OVER_LIMIT.format(
-                    db_gb=app.db_mb / 1000,
-                    limit_gb=app.db_limit_mb / 1000,
-                )
-            )
-        if hw.p_power > 0:
-            advice.append(REC_POWER_UNSTABLE)
-        if app.p_backup > 0:
-            advice.append(REC_BACKUP_STALE)
-        if app.update_count > 0:
-            advice.append(REC_UPDATES_PENDING.format(count=app.update_count))
-        if app.p_zombie > 0:
-            advice.append(REC_ZOMBIES.format(count=app.zombie_count))
-        if app.p_core_lag > 0:
-            advice.append(REC_CORE_LAG)
-        return advice
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    def _get_float(self, entity_id: str | None) -> float:
-        """Safely read a float value from an entity state."""
-        if not entity_id:
-            return 0.0
-        state = self.hass.states.get(entity_id)
-        if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-            return 0.0
-        try:
-            return float(state.state)
-        except (ValueError, TypeError):
-            return 0.0
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up HAGHS from a config entry."""
+
+    config = {**entry.data, **entry.options}
+    psi = await hass.async_add_executor_job(HaghsDataUpdateCoordinator._read_psi_sync)
+    if not psi.available and not (
+        CONF_CPU_SENSOR in config and CONF_RAM_SENSOR in config
+    ):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            IssueIds.FALLBACK_MISSING,
+            data={"entry_id": entry.entry_id},
+            is_fixable=True,
+            is_persistent=True,
+            severity=ir.IssueSeverity.CRITICAL,
+            translation_key=IssueIds.FALLBACK_MISSING,
+        )
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key=IssueIds.FALLBACK_MISSING,
+        )
+
+    ir.async_delete_issue(hass, DOMAIN, IssueIds.FALLBACK_MISSING)
+
     coordinator = HaghsDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
 
@@ -908,9 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def _async_update_options(
-    hass: HomeAssistant, entry: ConfigEntry
-) -> None:
+async def _async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload the integration when options change."""
     await hass.config_entries.async_reload(entry.entry_id)
 
@@ -921,3 +76,80 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    entry_version = VersionInformation(major=entry.version, minor=entry.minor_version)
+
+    _LOGGER.info("Migrating configuration from version %s", entry_version)
+
+    label_change_version = VersionInformation(major=3, minor=2)
+    if entry_version <= label_change_version:
+        if lr.DATA_REGISTRY not in hass.data:
+            await lr.async_load(hass)
+
+        label_registry = lr.async_get(hass)
+
+        data = dict(entry.data)
+        options = dict(entry.options)
+        data_changed = _migrate_ignore_label_value(label_registry, data)
+        options_changed = _migrate_ignore_label_value(label_registry, options)
+
+        if data_changed or options_changed:
+            _LOGGER.info("HAGHS: Migrated ignore label to label ID")
+
+        hass.config_entries.async_update_entry(
+            entry,
+            data=data,
+            options=options,
+            version=label_change_version.major,
+            minor_version=label_change_version.minor,
+        )
+
+    _LOGGER.info("Migration to version %s successful", entry_version)
+    return True
+
+
+def _migrate_ignore_label_value(
+    label_registry: lr.LabelRegistry,
+    config: dict[str, Any],
+) -> bool:
+    """Convert legacy text ignore label value into a label ID."""
+    label_value = config.get(CONF_IGNORE_LABEL, None)
+
+    if not label_value:
+        return True
+
+    # Idempotency guard: value is already a label ID — nothing to migrate.
+    # Without this, a future _CONFIG_VERSION bump would re-run this block on
+    # already-migrated entries, fail the name lookup, and create a new label
+    # whose name equals the existing label's ID.
+    if label_registry.async_get_label(label_value) is not None:
+        return True
+
+    if label := label_registry.async_get_label_by_name(label_value):
+        config[CONF_IGNORE_LABEL] = label.label_id
+        return True
+
+    try:
+        created = label_registry.async_create(label_value)
+    except ValueError:
+        # Handle races/case-normalization collisions.
+        if label := label_registry.async_get_label_by_name(label_value):
+            config[CONF_IGNORE_LABEL] = label.label_id
+            return True
+        _LOGGER.warning(
+            "HAGHS: Could not migrate ignore label '%s', clearing the value",
+            label_value,
+        )
+        config.pop(CONF_IGNORE_LABEL, None)
+        return True
+
+    config[CONF_IGNORE_LABEL] = created.label_id
+    _LOGGER.debug(
+        "HAGHS: Created label '%s' during migration (id=%s)",
+        label_value,
+        created.label_id,
+    )
+    return True

--- a/custom_components/haghs/config_flow.py
+++ b/custom_components/haghs/config_flow.py
@@ -1,8 +1,12 @@
 """Config flow and options flow for HAGHS integration."""
+
 from __future__ import annotations
+
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.const import UnitOfTime
 from homeassistant.helpers import selector
 
 from .const import (
@@ -16,13 +20,77 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     STORAGE_TYPES,
+    VersionInformation,
 )
+from .coordinator import HaghsDataUpdateCoordinator
+
+
+def _schema_with_psi(psi_available: bool) -> vol.Schema:
+    """Build flow schema based on PSI availability.
+
+    CPU/RAM are optional when PSI is available and required otherwise.
+    """
+    schema = {
+        vol.Optional(sensor) if psi_available else vol.Required(sensor): selector
+        for sensor, selector in FALLBACK_SENSORS_SCHEMA.items()
+    }
+    return vol.Schema(schema).extend(_BASE_SCHEMA)
+
+
+FALLBACK_SENSORS_SCHEMA = {
+    CONF_CPU_SENSOR: selector.EntitySelector(
+        selector.EntitySelectorConfig(
+            filter=(selector.EntityFilterSelectorConfig(domain="sensor"))
+        )
+    ),
+    CONF_RAM_SENSOR: selector.EntitySelector(
+        selector.EntitySelectorConfig(
+            filter=(selector.EntityFilterSelectorConfig(domain="sensor"))
+        )
+    ),
+}
+
+
+_BASE_SCHEMA = {
+    vol.Required(
+        CONF_STORAGE_TYPE, default=DEFAULT_STORAGE_TYPE
+    ): selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=STORAGE_TYPES,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+        )
+    ),
+    vol.Optional(CONF_IGNORE_LABEL): selector.LabelSelector(),
+    vol.Optional(CONF_DB_SENSOR): selector.EntitySelector(
+        selector.EntitySelectorConfig(
+            filter=selector.EntityFilterSelectorConfig(domain="sensor")
+        )
+    ),
+}
+
+_EXTRA_OPTIONS_SCHEMA = {
+    vol.Optional(
+        CONF_UPDATE_INTERVAL,
+        default=DEFAULT_UPDATE_INTERVAL,
+    ): selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=10,
+            max=3600,
+            step=1,
+            unit_of_measurement=UnitOfTime.SECONDS,
+            mode=selector.NumberSelectorMode.BOX,
+        )
+    )
+}
+
+_CONFIG_VERSION = VersionInformation(major=3, minor=2)
 
 
 class HaghsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for HAGHS."""
 
-    VERSION = 3
+    VERSION = _CONFIG_VERSION.major
+    MINOR_VERSION = _CONFIG_VERSION.minor
 
     @staticmethod
     def async_get_options_flow(
@@ -35,35 +103,13 @@ class HaghsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, str] | None = None
     ) -> config_entries.ConfigFlowResult:
         """Handle the initial step."""
-        if user_input is not None:
-            return self.async_create_entry(
-                title="Global Health Score", data=user_input
-            )
 
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_CPU_SENSOR): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor")
-                ),
-                vol.Required(CONF_RAM_SENSOR): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor")
-                ),
-                vol.Required(
-                    CONF_STORAGE_TYPE, default=DEFAULT_STORAGE_TYPE
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=STORAGE_TYPES,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-                vol.Optional(
-                    CONF_IGNORE_LABEL,
-                ): selector.LabelSelector(),
-                vol.Optional(CONF_DB_SENSOR): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor")
-                ),
-            }
+        if user_input is not None:
+            return self.async_create_entry(title="Global Health Score", data=user_input)
+        psi = await self.hass.async_add_executor_job(
+            HaghsDataUpdateCoordinator._read_psi_sync
         )
+        schema = _schema_with_psi(psi.available)
 
         return self.async_show_form(step_id="user", data_schema=schema)
 
@@ -76,7 +122,7 @@ class HaghsOptionsFlowHandler(config_entries.OptionsFlow):
         self._config_entry = config_entry
 
     async def async_step_init(
-        self, user_input: dict[str, any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> config_entries.ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
@@ -84,57 +130,15 @@ class HaghsOptionsFlowHandler(config_entries.OptionsFlow):
 
         # Current values: options take priority, then data, then defaults
         current = {**self._config_entry.data, **self._config_entry.options}
-
-        schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_CPU_SENSOR,
-                    default=current.get(CONF_CPU_SENSOR, ""),
-                ): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor")
-                ),
-                vol.Required(
-                    CONF_RAM_SENSOR,
-                    default=current.get(CONF_RAM_SENSOR, ""),
-                ): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor")
-                ),
-                vol.Required(
-                    CONF_STORAGE_TYPE,
-                    default=current.get(CONF_STORAGE_TYPE, DEFAULT_STORAGE_TYPE),
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=STORAGE_TYPES,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-                vol.Optional(
-                    CONF_IGNORE_LABEL,
-                    description={
-                        "suggested_value": current.get(CONF_IGNORE_LABEL),
-                    },
-                ): selector.LabelSelector(),
-                vol.Optional(
-                    CONF_DB_SENSOR,
-                    description={
-                        "suggested_value": current.get(CONF_DB_SENSOR, ""),
-                    },
-                ): selector.EntitySelector(
-                    selector.EntitySelectorConfig(domain="sensor")
-                ),
-                vol.Optional(
-                    CONF_UPDATE_INTERVAL,
-                    default=current.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=10,
-                        max=3600,
-                        step=1,
-                        unit_of_measurement="s",
-                        mode=selector.NumberSelectorMode.BOX,
-                    )
-                ),
-            }
+        psi = await self.hass.async_add_executor_job(
+            HaghsDataUpdateCoordinator._read_psi_sync
         )
+        schema = _schema_with_psi(psi.available).extend(_EXTRA_OPTIONS_SCHEMA)
 
-        return self.async_show_form(step_id="init", data_schema=schema)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                schema,
+                current,
+            ),
+        )

--- a/custom_components/haghs/config_flow.py
+++ b/custom_components/haghs/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import selector
 
 from .const import (
     _CONFIG_VERSION,
+    CONF_BATTERY_GRACE_MINUTES,
     CONF_CPU_SENSOR,
     CONF_DB_SENSOR,
     CONF_IGNORE_LABELS,
@@ -18,8 +19,11 @@ from .const import (
     CONF_RAM_SENSOR,
     CONF_STORAGE_TYPE,
     CONF_UPDATE_INTERVAL,
+    CONF_ZOMBIE_GRACE_MINUTES,
+    DEFAULT_BATTERY_GRACE_MINUTES,
     DEFAULT_STORAGE_TYPE,
     DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_ZOMBIE_GRACE_MINUTES,
     DOMAIN,
     STORAGE_TYPES,
 )
@@ -78,7 +82,31 @@ _EXTRA_OPTIONS_SCHEMA = {
             unit_of_measurement=UnitOfTime.SECONDS,
             mode=selector.NumberSelectorMode.BOX,
         )
-    )
+    ),
+    vol.Optional(
+        CONF_ZOMBIE_GRACE_MINUTES,
+        default=DEFAULT_ZOMBIE_GRACE_MINUTES,
+    ): selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=1,
+            max=240,
+            step=1,
+            unit_of_measurement=UnitOfTime.MINUTES,
+            mode=selector.NumberSelectorMode.BOX,
+        )
+    ),
+    vol.Optional(
+        CONF_BATTERY_GRACE_MINUTES,
+        default=DEFAULT_BATTERY_GRACE_MINUTES,
+    ): selector.NumberSelector(
+        selector.NumberSelectorConfig(
+            min=1,
+            max=240,
+            step=1,
+            unit_of_measurement=UnitOfTime.MINUTES,
+            mode=selector.NumberSelectorMode.BOX,
+        )
+    ),
 }
 
 

--- a/custom_components/haghs/config_flow.py
+++ b/custom_components/haghs/config_flow.py
@@ -13,7 +13,7 @@ from .const import (
     _CONFIG_VERSION,
     CONF_CPU_SENSOR,
     CONF_DB_SENSOR,
-    CONF_IGNORE_LABEL,
+    CONF_IGNORE_LABELS,
     CONF_IGNORE_PATTERNS,
     CONF_RAM_SENSOR,
     CONF_STORAGE_TYPE,
@@ -55,7 +55,9 @@ _BASE_SCHEMA = {
             mode=selector.SelectSelectorMode.DROPDOWN,
         )
     ),
-    vol.Optional(CONF_IGNORE_LABEL): selector.LabelSelector(),
+    vol.Optional(CONF_IGNORE_LABELS): selector.LabelSelector(
+        selector.LabelSelectorConfig(multiple=True)
+    ),
     vol.Optional(CONF_IGNORE_PATTERNS): selector.TextSelector(
         selector.TextSelectorConfig(multiple=True)
     ),

--- a/custom_components/haghs/config_flow.py
+++ b/custom_components/haghs/config_flow.py
@@ -39,22 +39,16 @@ def _schema_with_psi(psi_available: bool) -> vol.Schema:
 
 FALLBACK_SENSORS_SCHEMA = {
     CONF_CPU_SENSOR: selector.EntitySelector(
-        selector.EntitySelectorConfig(
-            filter=(selector.EntityFilterSelectorConfig(domain="sensor"))
-        )
+        selector.EntitySelectorConfig(filter=(selector.EntityFilterSelectorConfig(domain="sensor")))
     ),
     CONF_RAM_SENSOR: selector.EntitySelector(
-        selector.EntitySelectorConfig(
-            filter=(selector.EntityFilterSelectorConfig(domain="sensor"))
-        )
+        selector.EntitySelectorConfig(filter=(selector.EntityFilterSelectorConfig(domain="sensor")))
     ),
 }
 
 
 _BASE_SCHEMA = {
-    vol.Required(
-        CONF_STORAGE_TYPE, default=DEFAULT_STORAGE_TYPE
-    ): selector.SelectSelector(
+    vol.Required(CONF_STORAGE_TYPE, default=DEFAULT_STORAGE_TYPE): selector.SelectSelector(
         selector.SelectSelectorConfig(
             options=STORAGE_TYPES,
             mode=selector.SelectSelectorMode.DROPDOWN,
@@ -62,9 +56,7 @@ _BASE_SCHEMA = {
     ),
     vol.Optional(CONF_IGNORE_LABEL): selector.LabelSelector(),
     vol.Optional(CONF_DB_SENSOR): selector.EntitySelector(
-        selector.EntitySelectorConfig(
-            filter=selector.EntityFilterSelectorConfig(domain="sensor")
-        )
+        selector.EntitySelectorConfig(filter=selector.EntityFilterSelectorConfig(domain="sensor"))
     ),
 }
 
@@ -106,9 +98,7 @@ class HaghsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             return self.async_create_entry(title="Global Health Score", data=user_input)
-        psi = await self.hass.async_add_executor_job(
-            HaghsDataUpdateCoordinator._read_psi_sync
-        )
+        psi = await self.hass.async_add_executor_job(HaghsDataUpdateCoordinator._read_psi_sync)
         schema = _schema_with_psi(psi.available)
 
         return self.async_show_form(step_id="user", data_schema=schema)
@@ -130,9 +120,7 @@ class HaghsOptionsFlowHandler(config_entries.OptionsFlow):
 
         # Current values: options take priority, then data, then defaults
         current = {**self._config_entry.data, **self._config_entry.options}
-        psi = await self.hass.async_add_executor_job(
-            HaghsDataUpdateCoordinator._read_psi_sync
-        )
+        psi = await self.hass.async_add_executor_job(HaghsDataUpdateCoordinator._read_psi_sync)
         schema = _schema_with_psi(psi.available).extend(_EXTRA_OPTIONS_SCHEMA)
 
         return self.async_show_form(

--- a/custom_components/haghs/config_flow.py
+++ b/custom_components/haghs/config_flow.py
@@ -70,6 +70,29 @@ _BASE_SCHEMA = {
     ),
 }
 
+# Optional fields the user must be able to clear. Without this normalization a
+# missing key in user_input would never reach entry.options, and the
+# {**data, **options} merge in the coordinator would resurrect the original
+# value from entry.data after every HA restart (community bug report).
+_NULLABLE_OPTIONAL_KEYS: tuple[str, ...] = (
+    CONF_DB_SENSOR,
+    CONF_CPU_SENSOR,
+    CONF_RAM_SENSOR,
+    CONF_IGNORE_LABELS,
+    CONF_IGNORE_PATTERNS,
+)
+_LIST_OPTIONAL_KEYS: frozenset[str] = frozenset({CONF_IGNORE_LABELS, CONF_IGNORE_PATTERNS})
+
+
+def _normalize_optional(user_input: dict[str, Any]) -> dict[str, Any]:
+    """Force every leave-able optional field to an explicit None / []."""
+    for key in _NULLABLE_OPTIONAL_KEYS:
+        value = user_input.get(key)
+        if value in (None, "", []):
+            user_input[key] = [] if key in _LIST_OPTIONAL_KEYS else None
+    return user_input
+
+
 _EXTRA_OPTIONS_SCHEMA = {
     vol.Optional(
         CONF_UPDATE_INTERVAL,
@@ -129,7 +152,10 @@ class HaghsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
 
         if user_input is not None:
-            return self.async_create_entry(title="Global Health Score", data=user_input)
+            return self.async_create_entry(
+                title="Global Health Score",
+                data=_normalize_optional(user_input),
+            )
         psi = await self.hass.async_add_executor_job(HaghsDataUpdateCoordinator._read_psi_sync)
         schema = _schema_with_psi(psi.available)
 
@@ -148,7 +174,7 @@ class HaghsOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> config_entries.ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            return self.async_create_entry(title="", data=_normalize_optional(user_input))
 
         # Current values: options take priority, then data, then defaults
         current = {**self._config_entry.data, **self._config_entry.options}

--- a/custom_components/haghs/config_flow.py
+++ b/custom_components/haghs/config_flow.py
@@ -10,9 +10,11 @@ from homeassistant.const import UnitOfTime
 from homeassistant.helpers import selector
 
 from .const import (
+    _CONFIG_VERSION,
     CONF_CPU_SENSOR,
     CONF_DB_SENSOR,
     CONF_IGNORE_LABEL,
+    CONF_IGNORE_PATTERNS,
     CONF_RAM_SENSOR,
     CONF_STORAGE_TYPE,
     CONF_UPDATE_INTERVAL,
@@ -20,7 +22,6 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     STORAGE_TYPES,
-    VersionInformation,
 )
 from .coordinator import HaghsDataUpdateCoordinator
 
@@ -55,6 +56,9 @@ _BASE_SCHEMA = {
         )
     ),
     vol.Optional(CONF_IGNORE_LABEL): selector.LabelSelector(),
+    vol.Optional(CONF_IGNORE_PATTERNS): selector.TextSelector(
+        selector.TextSelectorConfig(multiple=True)
+    ),
     vol.Optional(CONF_DB_SENSOR): selector.EntitySelector(
         selector.EntitySelectorConfig(filter=selector.EntityFilterSelectorConfig(domain="sensor"))
     ),
@@ -74,8 +78,6 @@ _EXTRA_OPTIONS_SCHEMA = {
         )
     )
 }
-
-_CONFIG_VERSION = VersionInformation(major=3, minor=2)
 
 
 class HaghsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -1,5 +1,8 @@
 """Constants for the HAGHS integration."""
 
+from dataclasses import dataclass
+from enum import StrEnum
+
 DOMAIN = "haghs"
 
 # Config Keys
@@ -12,7 +15,6 @@ CONF_UPDATE_INTERVAL = "update_interval"
 
 # Defaults
 DEFAULT_NAME = "System: HA - Global Health Score"
-DEFAULT_IGNORE_LABEL = "haghs_ignore"
 DEFAULT_STORAGE_TYPE = "sd-card"
 DEFAULT_UPDATE_INTERVAL = 60  # seconds
 
@@ -46,3 +48,20 @@ REC_ALL_CLEAR = "\u2705 System optimized"
 
 # Fallback text for empty lists in state attributes
 ATTR_NONE = "None"
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class VersionInformation:
+    """Version information."""
+
+    def __repr__(self) -> str:
+        return f"{self.major}.{self.minor}"
+
+    major: int
+    minor: int
+
+
+class IssueIds(StrEnum):
+    """Issue ids."""
+
+    FALLBACK_MISSING = "fallback_missing"

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -36,6 +36,13 @@ DATA_BOOT_TIME = "_boot_time"
 ZOMBIE_GRACE_SECONDS = 15 * 60
 BATTERY_GRACE_SECONDS = 60 * 60
 
+# Maximum number of entity ids carried in the `zombie_entities` state
+# attribute. The Home Assistant state machine caps the entire attribute
+# payload at 16 KB; 100 entity ids (with the `[unregistered] ` prefix
+# accounted for) stay well below that. `zombie_count` and the per-domain
+# breakdown always reflect the full count, only the listing is capped.
+ZOMBIE_LIST_CAP = 100
+
 # Internal hass.data key holding the per-entity first-seen timestamps for
 # pending updates (#26). Only updates that have been available longer than
 # UPDATE_GRACE_DAYS contribute to the update_count penalty; this avoids

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -16,6 +16,8 @@ CONF_IGNORE_LABELS = "ignore_labels"
 CONF_IGNORE_PATTERNS = "ignore_patterns"
 CONF_STORAGE_TYPE = "storage_type"
 CONF_UPDATE_INTERVAL = "update_interval"
+CONF_ZOMBIE_GRACE_MINUTES = "zombie_grace_minutes"
+CONF_BATTERY_GRACE_MINUTES = "battery_grace_minutes"
 
 # Defaults
 DEFAULT_NAME = "System: HA - Global Health Score"
@@ -29,12 +31,14 @@ STORAGE_TYPES: list[str] = ["sd-card", "ssd", "emmc"]
 # detection to ignore last_changed values restored from the recorder.
 DATA_BOOT_TIME = "_boot_time"
 
-# Grace period (seconds) before an unavailable entity becomes a zombie.
-# Battery-class entities use the extended window because Zigbee/Homematic
-# coordinators routinely take longer than 15 minutes to re-poll low-priority
-# devices after a restart (#62).
-ZOMBIE_GRACE_SECONDS = 15 * 60
-BATTERY_GRACE_SECONDS = 60 * 60
+# Grace periods (minutes) before an unavailable / unknown entity becomes a
+# zombie. Both values are user-configurable in the OptionsFlow; the values
+# below are the defaults if nothing is set. Battery-class entities get a
+# separate, typically longer window because Zigbee / Homematic coordinators
+# routinely take longer than 15 minutes to re-poll low-priority devices
+# after a restart (#62).
+DEFAULT_ZOMBIE_GRACE_MINUTES = 15
+DEFAULT_BATTERY_GRACE_MINUTES = 60
 
 # Maximum number of entity ids carried in the `zombie_entities` state
 # attribute. The Home Assistant state machine caps the entire attribute

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -31,8 +31,14 @@ DATA_BOOT_TIME = "_boot_time"
 #
 # Templates use str.format() placeholders so translations can reorder them.
 # ---------------------------------------------------------------------------
-REC_CPU_LOAD = "\u26a1 Optimization: CPU load is impacting score ({cpu_pct:.1f}%)."
-REC_RAM_PRESSURE = "\u26a1 Optimization: Memory pressure is impacting score ({ram_pct:.1f}%)."
+REC_CPU_LOAD_PSI = "\u26a1 Optimization: PSI CPU stall time is impacting score ({cpu_pct:.1f}%)."
+REC_CPU_LOAD_CLASSIC = "\u26a1 Optimization: CPU utilization is impacting score ({cpu_pct:.1f}%)."
+REC_RAM_PRESSURE_PSI = (
+    "\u26a1 Optimization: PSI memory stall time is impacting score ({ram_pct:.1f}%)."
+)
+REC_RAM_PRESSURE_CLASSIC = (
+    "\u26a1 Optimization: Memory utilization is impacting score ({ram_pct:.1f}%)."
+)
 REC_IO_PRESSURE = "\u26a1 Optimization: I/O pressure is impacting score ({io_pct:.1f}%)."
 REC_DISK_SD_LOW = "\u26a0\ufe0f Disk Space: Only {free_gb:.1f} GB free on {storage_type}!"
 REC_DISK_SSD_LOW = "\u26a0\ufe0f Disk Space: Less than 10% free ({free_gb:.1f} GB)!"

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -48,6 +48,11 @@ REC_ALL_CLEAR = "\u2705 System optimized"
 # Fallback text for empty lists in state attributes
 ATTR_NONE = "None"
 
+# Marker prefix for zombie entities that exist in the state machine but
+# have no entity registry entry. Surfaces these "ghost" entities in the
+# zombie_entities attribute so users can locate them in HA logs.
+ATTR_UNREGISTERED_PREFIX = "[unregistered] "
+
 
 @dataclass(frozen=True, slots=True, order=True)
 class VersionInformation:

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -60,6 +60,24 @@ ATTR_NONE = "None"
 # zombie_entities attribute so users can locate them in HA logs.
 ATTR_UNREGISTERED_PREFIX = "[unregistered] "
 
+# Boolean recommendation flags exposed as state attributes alongside the
+# existing 'recommendations' string. Dashboards and external integrations
+# (e.g. HA Pulse) read these via state_attr(sensor, 'rec_*') instead of
+# parsing the rendered text. Keep this in sync with _build_rec_flags() in
+# coordinator.py.
+REC_FLAG_KEYS: tuple[str, ...] = (
+    "rec_cpu_load",
+    "rec_ram_pressure",
+    "rec_io_pressure",
+    "rec_disk_low",
+    "rec_db_over_limit",
+    "rec_power_unstable",
+    "rec_backup_stale",
+    "rec_updates_pending",
+    "rec_zombie",
+    "rec_core_lag",
+)
+
 
 @dataclass(frozen=True, slots=True, order=True)
 class VersionInformation:

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -10,6 +10,7 @@ CONF_CPU_SENSOR = "cpu_sensor"
 CONF_RAM_SENSOR = "ram_sensor"
 CONF_DB_SENSOR = "db_sensor"
 CONF_IGNORE_LABEL = "ignore_label"
+CONF_IGNORE_PATTERNS = "ignore_patterns"
 CONF_STORAGE_TYPE = "storage_type"
 CONF_UPDATE_INTERVAL = "update_interval"
 
@@ -69,3 +70,9 @@ class IssueIds(StrEnum):
     """Issue ids."""
 
     FALLBACK_MISSING = "fallback_missing"
+
+
+# Current config entry version. Bumped whenever entry.data/options need
+# migration. Keep this in const.py so both config_flow and the migration
+# logic in __init__.py reference the same source of truth.
+_CONFIG_VERSION = VersionInformation(major=3, minor=3)

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -29,15 +29,10 @@ STORAGE_TYPES: list[str] = ["sd-card", "ssd", "emmc"]
 REC_CPU_LOAD = "\u26a1 Optimization: CPU load is impacting score ({cpu_pct:.1f}%)."
 REC_RAM_PRESSURE = "\u26a1 Optimization: Memory pressure is impacting score ({ram_pct:.1f}%)."
 REC_IO_PRESSURE = "\u26a1 Optimization: I/O pressure is impacting score ({io_pct:.1f}%)."
-REC_DISK_SD_LOW = (
-    "\u26a0\ufe0f Disk Space: Only {free_gb:.1f} GB free on {storage_type}!"
-)
-REC_DISK_SSD_LOW = (
-    "\u26a0\ufe0f Disk Space: Less than 10% free ({free_gb:.1f} GB)!"
-)
+REC_DISK_SD_LOW = "\u26a0\ufe0f Disk Space: Only {free_gb:.1f} GB free on {storage_type}!"
+REC_DISK_SSD_LOW = "\u26a0\ufe0f Disk Space: Less than 10% free ({free_gb:.1f} GB)!"
 REC_DB_OVER_LIMIT = (
-    "\U0001f5c4\ufe0f Database: DB ({db_gb:.1f} GB) exceeds "
-    "dynamic limit ({limit_gb:.1f} GB)."
+    "\U0001f5c4\ufe0f Database: DB ({db_gb:.1f} GB) exceeds dynamic limit ({limit_gb:.1f} GB)."
 )
 REC_BACKUP_STALE = "\U0001f6a8 Security: Stale backup detected!"
 REC_UPDATES_PENDING = "\U0001f4e6 Maintenance: {count} update(s) pending."

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -21,6 +21,10 @@ DEFAULT_UPDATE_INTERVAL = 60  # seconds
 # Storage type choices for the config flow dropdown
 STORAGE_TYPES: list[str] = ["sd-card", "ssd", "emmc"]
 
+# Internal hass.data key holding the boot-time baseline used by zombie
+# detection to ignore last_changed values restored from the recorder.
+DATA_BOOT_TIME = "_boot_time"
+
 # ---------------------------------------------------------------------------
 # Recommendation templates (i18n-ready — mirrored in strings.json)
 #

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -26,6 +26,20 @@ STORAGE_TYPES: list[str] = ["sd-card", "ssd", "emmc"]
 # detection to ignore last_changed values restored from the recorder.
 DATA_BOOT_TIME = "_boot_time"
 
+# Grace period (seconds) before an unavailable entity becomes a zombie.
+# Battery-class entities use the extended window because Zigbee/Homematic
+# coordinators routinely take longer than 15 minutes to re-poll low-priority
+# devices after a restart (#62).
+ZOMBIE_GRACE_SECONDS = 15 * 60
+BATTERY_GRACE_SECONDS = 60 * 60
+
+# Internal hass.data key holding the per-entity first-seen timestamps for
+# pending updates (#26). Only updates that have been available longer than
+# UPDATE_GRACE_DAYS contribute to the update_count penalty; this avoids
+# punishing normal user behaviour (most updates land within a few days).
+DATA_UPDATE_FIRST_SEEN = "_update_first_seen"
+UPDATE_GRACE_DAYS = 7
+
 # ---------------------------------------------------------------------------
 # Recommendation templates (i18n-ready — mirrored in strings.json)
 #

--- a/custom_components/haghs/const.py
+++ b/custom_components/haghs/const.py
@@ -9,7 +9,10 @@ DOMAIN = "haghs"
 CONF_CPU_SENSOR = "cpu_sensor"
 CONF_RAM_SENSOR = "ram_sensor"
 CONF_DB_SENSOR = "db_sensor"
+# CONF_IGNORE_LABEL is deprecated since v3.4 — kept here for the migration
+# step that converts the legacy single label into CONF_IGNORE_LABELS.
 CONF_IGNORE_LABEL = "ignore_label"
+CONF_IGNORE_LABELS = "ignore_labels"
 CONF_IGNORE_PATTERNS = "ignore_patterns"
 CONF_STORAGE_TYPE = "storage_type"
 CONF_UPDATE_INTERVAL = "update_interval"
@@ -113,4 +116,4 @@ class IssueIds(StrEnum):
 # Current config entry version. Bumped whenever entry.data/options need
 # migration. Keep this in const.py so both config_flow and the migration
 # logic in __init__.py reference the same source of truth.
-_CONFIG_VERSION = VersionInformation(major=3, minor=3)
+_CONFIG_VERSION = VersionInformation(major=3, minor=4)

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -635,6 +635,13 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ),
         )
 
+        # Hard cap: a perfect 100 must always reflect zero detected issues.
+        # On large instances the ratio-based p_zombie can be small enough
+        # that config_bonus fully offsets it, which would otherwise hide
+        # existing zombies behind a 100 score.
+        if zombie_count > 0:
+            app_final = min(99, app_final)
+
         return _ApplicationResult(
             app_score=app_final,
             zombie_count=zombie_count,

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -29,6 +29,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    ATTR_UNREGISTERED_PREFIX,
     CONF_CPU_SENSOR,
     CONF_DB_SENSOR,
     CONF_IGNORE_LABEL,
@@ -184,6 +185,10 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # than the latest reload. setdefault preserves an existing value.
         hass_data = hass.data.setdefault(DOMAIN, {})
         self._boot_time = hass_data.setdefault(DATA_BOOT_TIME, dt_util.utcnow())
+
+        # Track ghost zombies (no entity-registry entry) so we warn at most
+        # once per entity per coordinator instance instead of every refresh.
+        self._logged_ghost_entities: set[str] = set()
 
         # Registry-race guard: if HAGHS first runs while HA is still in the
         # 'starting' state, the entity registry (and therefore label
@@ -644,7 +649,22 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     is_ignored = True
 
             if not is_ignored:
-                zombie_list.append(entity_id)
+                if entity_entry is None:
+                    # Ghost zombie: exists in the state machine but has no
+                    # entity registry entry, so it cannot be managed in the
+                    # HA UI. Surface it explicitly and warn once per id (#6).
+                    if entity_id not in self._logged_ghost_entities:
+                        _LOGGER.warning(
+                            "HAGHS: Detected unregistered zombie entity '%s'. "
+                            "It exists in the state machine but has no entity "
+                            "registry entry, so it cannot be managed via the "
+                            "HA UI. Check the integration that created it.",
+                            entity_id,
+                        )
+                        self._logged_ghost_entities.add(entity_id)
+                    zombie_list.append(f"{ATTR_UNREGISTERED_PREFIX}{entity_id}")
+                else:
+                    zombie_list.append(entity_id)
 
         zombie_count = len(zombie_list)
 

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -1,0 +1,893 @@
+"""HAGHS coordinator."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any
+
+import psutil
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    device_registry as dr,
+)
+from homeassistant.helpers import (
+    entity_registry as er,
+)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    CONF_CPU_SENSOR,
+    CONF_DB_SENSOR,
+    CONF_IGNORE_LABEL,
+    CONF_RAM_SENSOR,
+    CONF_STORAGE_TYPE,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_STORAGE_TYPE,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    REC_ALL_CLEAR,
+    REC_BACKUP_STALE,
+    REC_CORE_LAG,
+    REC_CPU_LOAD,
+    REC_DB_OVER_LIMIT,
+    REC_DISK_SD_LOW,
+    REC_DISK_SSD_LOW,
+    REC_IO_PRESSURE,
+    REC_POWER_UNSTABLE,
+    REC_RAM_PRESSURE,
+    REC_UPDATES_PENDING,
+    REC_ZOMBIES,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[str] = ["sensor"]
+
+# Size constants
+_GB = 1024**3
+
+# Timeout for each scoring sub-calculation (seconds).
+PILLAR_TIMEOUT: float = 10.0
+
+# Default HA SQLite database filename
+HA_DB_NAME = "home-assistant_v2.db"
+
+# PSI (Pressure Stall Information) paths — Linux only
+PSI_CPU_PATH = "/proc/pressure/cpu"
+PSI_MEMORY_PATH = "/proc/pressure/memory"
+PSI_IO_PATH = "/proc/pressure/io"
+
+# Regex to extract 'some avg10=X.XX' from PSI files
+_PSI_SOME_AVG10_RE = re.compile(r"some\s+avg10=(\d+\.?\d*)")
+
+# Domains to check for zombie entities
+ZOMBIE_DOMAINS: frozenset[str] = frozenset(
+    [
+        "sensor",
+        "binary_sensor",
+        "switch",
+        "light",
+        "fan",
+        "climate",
+        "media_player",
+        "vacuum",
+        "camera",
+    ]
+)
+
+
+@dataclass
+class _PsiData:
+    """Pressure Stall Information (some avg10 values).
+
+    None means the file could not be read (unsupported platform / old kernel).
+    """
+
+    cpu: float | None = None
+    memory: float | None = None
+    io: float | None = None
+
+    @property
+    def available(self) -> bool:
+        """Return True if at least CPU and memory PSI data was read."""
+        return self.cpu is not None and self.memory is not None
+
+
+@dataclass
+class _HardwareResult:
+    """Result of the hardware pillar calculation."""
+
+    hardware_score: float = 100.0
+    cpu: float = 0.0
+    ram: float = 0.0
+    io: float = 0.0
+    disk: float = 0.0
+    disk_total: int = 0
+    disk_free: int = 0
+    p_cpu: int = 0
+    p_ram: int = 0
+    p_io: int = 0
+    p_power: int = 0
+    psi_available: bool = False
+
+
+@dataclass
+class _ApplicationResult:
+    """Result of the application pillar calculation."""
+
+    app_score: int = 100
+    zombie_count: int = 0
+    zombie_list: list[str] = field(default_factory=list)
+    db_mb: float = 0.0
+    db_limit_mb: float = 1000.0
+    update_count: int = 0
+    pending_updates: list[str] = field(default_factory=list)
+    config_bonus: int = 0
+    p_backup: int = 0
+    p_core_lag: int = 0
+    p_zombie: int = 0
+
+
+@dataclass
+class _RecorderInfo:
+    """Recorder configuration data — prepared for Phase 3 scoring."""
+
+    keep_days: int | None = None
+    entity_filter_active: bool = False
+    available: bool = False
+
+
+class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Coordinator that calculates the Global Health Score."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the coordinator."""
+        # Options take priority over data for runtime-configurable fields
+        opts: dict = {**entry.data, **entry.options}
+
+        interval_sec = int(opts.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=interval_sec),
+        )
+        self.cpu_id: str | None = opts.get(CONF_CPU_SENSOR)
+        self.ram_id: str | None = opts.get(CONF_RAM_SENSOR)
+        self.db_sensor_id: str | None = opts.get(CONF_DB_SENSOR) or None
+        self.ignore_label: str | None = opts.get(CONF_IGNORE_LABEL)
+        self._storage_type: str = opts.get(CONF_STORAGE_TYPE, DEFAULT_STORAGE_TYPE)
+
+        # Paths for auto-detection (resolved once at init)
+        self._db_path: str = hass.config.path(HA_DB_NAME)
+        self._config_dir: str = hass.config.config_dir
+
+        # Recorder info — populated on each update cycle (Phase 3 ready)
+        self.recorder_info: _RecorderInfo = _RecorderInfo()
+
+    # ------------------------------------------------------------------
+    # Main update — orchestrates sub-calculations with safety net
+    # ------------------------------------------------------------------
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data and calculate the health score.
+
+        Each pillar runs in its own guarded coroutine.  On timeout or
+        exception the affected pillar falls back to a neutral score
+        (100 / no penalty) and a warning is logged.  The coordinator
+        itself never crashes.
+        """
+        # Recorder info — read before app pillar so config audit can use it
+        self.recorder_info = self._read_recorder_info()
+
+        hw = await self._safe_calc(
+            "hardware",
+            self._async_calc_hardware(),
+            _HardwareResult(),
+        )
+
+        app = await self._safe_calc(
+            "application",
+            self._async_calc_application(),
+            _ApplicationResult(),
+        )
+
+        global_score = max(
+            0, min(100, math.floor((hw.hardware_score * 0.4) + (app.app_score * 0.6)))
+        )
+
+        advice = self._build_recommendations(hw, app)
+
+        return {
+            "global_score": int(global_score),
+            "hardware_score": int(hw.hardware_score),
+            "application_score": app.app_score,
+            "zombie_count": app.zombie_count,
+            "zombie_entities": app.zombie_list,
+            "db_size_mb": round(app.db_mb, 1),
+            "psi_available": hw.psi_available,
+            "recorder_keep_days": self.recorder_info.keep_days,
+            "recorder_filter_active": self.recorder_info.entity_filter_active,
+            "pending_updates": app.pending_updates,
+            "recommendations": ("\n".join(advice) if advice else REC_ALL_CLEAR),
+        }
+
+    async def _safe_calc(
+        self,
+        name: str,
+        coro: Any,
+        fallback: Any,
+    ) -> Any:
+        """Run *coro* with a timeout; return *fallback* on any failure."""
+        try:
+            return await asyncio.wait_for(coro, timeout=PILLAR_TIMEOUT)
+        except TimeoutError:
+            _LOGGER.warning(
+                "HAGHS: %s calculation timed out after %ss — using neutral score",
+                name,
+                PILLAR_TIMEOUT,
+            )
+            return fallback
+        except Exception:
+            _LOGGER.warning(
+                "HAGHS: %s calculation failed — using neutral score",
+                name,
+                exc_info=True,
+            )
+            return fallback
+
+    # ------------------------------------------------------------------
+    # PSI (Pressure Stall Information) reader
+    # ------------------------------------------------------------------
+
+    async def _async_read_psi(self) -> _PsiData:
+        """Read Linux PSI data from /proc/pressure via executor.
+
+        Returns _PsiData with None fields for any file that cannot be read
+        (Windows, old kernels, containers without /proc mounted).
+        """
+        return await self.hass.async_add_executor_job(self._read_psi_sync)
+
+    @staticmethod
+    def _read_psi_sync() -> _PsiData:
+        """Synchronous PSI reader — runs in the executor thread pool."""
+        return _PsiData(
+            cpu=HaghsDataUpdateCoordinator._parse_psi_file(PSI_CPU_PATH),
+            memory=HaghsDataUpdateCoordinator._parse_psi_file(PSI_MEMORY_PATH),
+            io=HaghsDataUpdateCoordinator._parse_psi_file(PSI_IO_PATH),
+        )
+
+    @staticmethod
+    def _parse_psi_file(path: str) -> float | None:
+        """Parse 'some avg10' from a single PSI file.  Returns None on failure."""
+        try:
+            with open(path, encoding="utf-8") as fh:
+                content = fh.read()
+            match = _PSI_SOME_AVG10_RE.search(content)
+            if match:
+                return float(match.group(1))
+            return None
+        except (OSError, ValueError):
+            return None
+
+    # ------------------------------------------------------------------
+    # Hardware pillar (40 %)
+    # ------------------------------------------------------------------
+
+    async def _async_calc_hardware(self) -> _HardwareResult:
+        """Calculate the hardware pillar score.
+
+        Data sources — with smart fallback:
+          CPU:  PSI /proc/pressure/cpu some avg10  → fallback: CONF_CPU_SENSOR
+          RAM:  PSI /proc/pressure/memory some avg10  → fallback: CONF_RAM_SENSOR
+          I/O:  PSI /proc/pressure/io some avg10  (PSI-only, no fallback)
+          Disk: psutil.disk_usage (always auto-detected)
+
+        PSI values measure stall time (% of time tasks waited for a resource).
+        Classic sensor values measure utilization (% of resource in use).
+        These require separate threshold tiers because their scales differ
+        fundamentally.
+        """
+        # Try PSI first (non-blocking via executor)
+        psi = await self._async_read_psi()
+        use_psi = psi.available
+
+        # -- CPU --
+        if psi.cpu is not None:
+            cpu = psi.cpu
+            p_cpu = self._psi_cpu_penalty(cpu)
+        else:
+            cpu = self._get_float(self.cpu_id)
+            if cpu > 100:
+                _LOGGER.warning(
+                    "HAGHS: CPU sensor '%s' returned %.1f — expected 0-100%%. "
+                    "Please select a sensor that reports CPU usage in percent",
+                    self.cpu_id,
+                    cpu,
+                )
+                cpu = min(cpu, 100.0)
+            p_cpu = self._classic_cpu_penalty(cpu)
+        score_cpu = 100 - p_cpu
+
+        # -- RAM --
+        if psi.memory is not None:
+            ram = psi.memory
+            p_ram = self._psi_memory_penalty(ram)
+        else:
+            ram = self._get_float(self.ram_id)
+            if ram > 100:
+                _LOGGER.warning(
+                    "HAGHS: RAM sensor '%s' returned %.1f — expected 0-100%%. "
+                    "Please select a sensor that reports memory usage in percent",
+                    self.ram_id,
+                    ram,
+                )
+                ram = min(ram, 100.0)
+            p_ram = self._classic_ram_penalty(ram)
+        score_ram = 100 - p_ram
+
+        # -- I/O (PSI-only — no classic fallback) --
+        io_val = psi.io if psi.io is not None else 0.0
+        p_io = 0
+        if psi.io is not None:
+            p_io = self._psi_io_penalty(psi.io)
+        score_io = 100 - p_io
+
+        # -- Disk: always auto-detected via psutil — smart thresholds --
+        disk_usage = await self._async_get_disk_usage()
+        if disk_usage is not None:
+            disk_total = disk_usage.total
+            disk_free = disk_usage.free
+            disk_pct = disk_usage.percent
+
+            if self._storage_type in ("sd-card", "emmc"):
+                # SD-Card / eMMC logic: critical < 3 GB free, warning < 5 GB free
+                if disk_free < 3 * _GB:
+                    score_disk = 0.0
+                elif disk_free < 5 * _GB:
+                    score_disk = 50.0
+                else:
+                    score_disk = 100.0
+            else:
+                # SSD logic: warning < 10% free
+                free_pct = (disk_free / disk_total) * 100 if disk_total > 0 else 100
+                if free_pct < 10:
+                    score_disk = max(0.0, free_pct * 10)
+                else:
+                    score_disk = 100.0
+        else:
+            disk_total = 0
+            disk_free = 0
+            disk_pct = 0.0
+            score_disk = 100.0
+
+        # -- Power Supply (RPi auto-detection) --
+        p_power = 0
+        power_state = self.hass.states.get("binary_sensor.rpi_power_status")
+        if power_state and power_state.state == "on":
+            p_power = 20
+
+        # -- Final hardware score --
+        # When PSI I/O is available: 4 components (CPU, RAM, I/O, Disk)
+        # When I/O is not available: 3 components (CPU, RAM, Disk)
+        # Power penalty is applied as a flat deduction (not averaged)
+        if psi.io is not None:
+            hardware_final = max(
+                0.0,
+                min(
+                    100.0, (score_cpu + score_ram + score_io + score_disk) / 4 - p_power
+                ),
+            )
+        else:
+            hardware_final = max(
+                0.0,
+                min(100.0, (score_cpu + score_ram + score_disk) / 3 - p_power),
+            )
+
+        if use_psi:
+            _LOGGER.debug(
+                "HAGHS: Using PSI data — cpu=%.2f memory=%.2f io=%s",
+                psi.cpu,
+                psi.memory,
+                psi.io,
+            )
+        else:
+            _LOGGER.debug("HAGHS: PSI not available — using sensor fallback")
+
+        return _HardwareResult(
+            hardware_score=hardware_final,
+            cpu=cpu,
+            ram=ram,
+            io=io_val,
+            disk=disk_pct,
+            disk_total=disk_total,
+            disk_free=disk_free,
+            p_cpu=p_cpu,
+            p_ram=p_ram,
+            p_io=p_io,
+            p_power=p_power,
+            psi_available=use_psi,
+        )
+
+    # -- CPU penalty tiers -------------------------------------------------
+
+    @staticmethod
+    def _classic_cpu_penalty(cpu: float) -> int:
+        """Tiered penalty for classic CPU usage sensor (utilization %).
+
+        Classic sensors report how busy the CPU is.  25% is normal for an
+        active system, so penalties only start above that threshold.
+        """
+        if cpu <= 25:
+            return 0
+        if cpu <= 40:
+            return 10
+        if cpu <= 60:
+            return 25
+        if cpu <= 80:
+            return 50
+        return 80
+
+    @staticmethod
+    def _psi_cpu_penalty(psi_val: float) -> int:
+        """Tiered penalty for PSI CPU pressure (stall time %).
+
+        PSI measures how long tasks waited for CPU.  Even 5% stall time
+        is noticeable — automation latency increases measurably.
+        """
+        if psi_val <= 5:
+            return 0
+        if psi_val <= 15:
+            return 10
+        if psi_val <= 30:
+            return 25
+        if psi_val <= 50:
+            return 50
+        return 80
+
+    # -- RAM penalty tiers -------------------------------------------------
+
+    @staticmethod
+    def _classic_ram_penalty(ram: float) -> int:
+        """Tiered penalty for classic RAM usage sensor (utilization %).
+
+        HA + Supervisor typically consume 60-70% of RAM.  Penalties start
+        at 70% with a linear ramp to leave headroom for spikes.
+        """
+        if ram < 70:
+            return 0
+        if ram < 80:
+            return int((ram - 70) * 3.33)  # 0 → 33
+        if ram < 90:
+            return int(33 + (ram - 80) * 3.37)  # 33 → 67
+        return 80
+
+    @staticmethod
+    def _psi_memory_penalty(psi_val: float) -> int:
+        """Tiered penalty for PSI memory pressure (stall time %).
+
+        Memory stalls are more critical than CPU stalls because they can
+        trigger the OOM killer.  Thresholds are tighter than CPU.
+        """
+        if psi_val <= 5:
+            return 0
+        if psi_val <= 10:
+            return 10
+        if psi_val <= 25:
+            return 25
+        if psi_val <= 40:
+            return 50
+        return 80
+
+    # -- I/O penalty tiers -------------------------------------------------
+
+    @staticmethod
+    def _psi_io_penalty(psi_val: float) -> int:
+        """Tiered penalty for PSI I/O pressure (stall time %).
+
+        I/O stalls directly affect recorder writes, automation execution,
+        and restart times.  Thresholds match CPU PSI.
+        """
+        if psi_val <= 5:
+            return 0
+        if psi_val <= 15:
+            return 10
+        if psi_val <= 30:
+            return 25
+        if psi_val <= 50:
+            return 50
+        return 80
+
+    async def _async_get_disk_usage(self) -> Any | None:
+        """Return full psutil disk_usage result, or None on failure."""
+        try:
+            return await self.hass.async_add_executor_job(
+                psutil.disk_usage, self._config_dir
+            )
+        except (OSError, FileNotFoundError):
+            _LOGGER.warning(
+                "HAGHS: Could not read disk usage for %s — assuming healthy",
+                self._config_dir,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Application pillar (60 %)
+    # ------------------------------------------------------------------
+
+    async def _async_calc_application(self) -> _ApplicationResult:
+        """Calculate the application pillar score."""
+        # A. ZOMBIES
+        zombie_list, p_zombie, zombie_count = self._calc_zombies()
+
+        # B. INTEGRATION HEALTH
+        p_integration = self._calc_integration_health()
+
+        # C. MAINTENANCE — DB size auto-detected (blocking I/O → executor)
+        db_mb, p_db, db_limit_mb = await self._async_calc_maintenance()
+
+        # D. UPDATES
+        p_backup, update_count, p_updates, p_core_lag, pending_updates = (
+            self._calc_updates()
+        )
+
+        # E. CONFIG AUDIT — bonus for good recorder configuration
+        config_bonus = self._calc_config_audit()
+
+        app_final = max(
+            0,
+            min(
+                100,
+                100
+                - p_zombie
+                - p_integration
+                - p_backup
+                - p_updates
+                - p_db
+                + config_bonus,
+            ),
+        )
+
+        return _ApplicationResult(
+            app_score=app_final,
+            zombie_count=zombie_count,
+            zombie_list=zombie_list,
+            db_mb=db_mb,
+            db_limit_mb=db_limit_mb,
+            update_count=update_count,
+            pending_updates=pending_updates,
+            config_bonus=config_bonus,
+            p_backup=p_backup,
+            p_core_lag=p_core_lag,
+            p_zombie=p_zombie,
+        )
+
+    # ------------------------------------------------------------------
+    # Application sub-calculations
+    # ------------------------------------------------------------------
+
+    def _calc_zombies(self) -> tuple[list[str], int, int]:
+        """Detect zombie entities, respecting ignore labels and grace period.
+
+        Returns (zombie_list_capped, p_zombie, zombie_count).
+        zombie_list is capped to 20 entries for state attributes;
+        zombie_count always reflects the full number.
+        """
+        ent_reg = er.async_get(self.hass)
+        dev_reg = dr.async_get(self.hass)
+        now = dt_util.utcnow()
+        zombie_list: list[str] = []
+
+        for state in self.hass.states.async_all():
+            if state.domain not in ZOMBIE_DOMAINS:
+                continue
+            if state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+                continue
+
+            # Grace period: skip entities that changed < 15 min ago
+            if (now - state.last_changed).total_seconds() < 900:
+                continue
+
+            entity_id = state.entity_id
+            if "integration_health" in entity_id:
+                continue
+
+            is_ignored = False
+            entity_entry = ent_reg.async_get(entity_id)
+            if entity_entry and self.ignore_label in (entity_entry.labels or set()):
+                is_ignored = True
+
+            if not is_ignored and entity_entry and entity_entry.device_id:
+                device_entry = dev_reg.async_get(entity_entry.device_id)
+                if device_entry and self.ignore_label in (device_entry.labels or set()):
+                    is_ignored = True
+
+            if not is_ignored:
+                zombie_list.append(entity_id)
+
+        zombie_count = len(zombie_list)
+
+        # Ratio-based penalty: percentage of zombies relative to total entities
+        # Factor 7 + ceil ensures zombies are visible on all instance sizes
+        total_entities = len(self.hass.states.async_all())
+        if total_entities > 0:
+            zombie_ratio_pct = (zombie_count / total_entities) * 100
+            p_zombie = min(20, math.ceil(zombie_ratio_pct * 7))
+        else:
+            p_zombie = 0
+
+        # Cap the list for state attributes (count stays full)
+        return zombie_list[:20], p_zombie, zombie_count
+
+    def _calc_integration_health(self) -> int:
+        """Count unhealthy integrations via native ConfigEntry states.
+
+        Checks for integrations stuck in SETUP_ERROR, SETUP_RETRY, or
+        FAILED_UNLOAD — the same states HA shows as "error" in the UI.
+        Penalty: 5 pts per unhealthy integration, capped at 15.
+        """
+        unhealthy_states = {
+            ConfigEntryState.SETUP_ERROR,
+            ConfigEntryState.SETUP_RETRY,
+            ConfigEntryState.FAILED_UNLOAD,
+        }
+        failed = sum(
+            1
+            for entry in self.hass.config_entries.async_entries()
+            if entry.state in unhealthy_states
+        )
+        return min(15, failed * 5)
+
+    async def _async_calc_maintenance(self) -> tuple[float, int, float]:
+        """Calculate DB penalty with dynamic limit based on entity count."""
+        db_mb = await self._async_get_db_size_mb()
+        total_entities = len(self.hass.states.async_all())
+        db_limit_mb = 1000 + (total_entities * 2.5)
+
+        p_db = 0
+        if db_mb < db_limit_mb:
+            p_db = 0
+        elif db_mb < db_limit_mb * 2.5:
+            p_db = 10
+        else:
+            p_db = 30
+
+        return db_mb, p_db, db_limit_mb
+
+    async def _async_get_db_size_mb(self) -> float:
+        """Return the HA database size in MB.
+
+        If an external DB sensor is configured, its state is used directly
+        (expected to report size in MB).  Otherwise falls back to measuring
+        the local SQLite file via os.path.getsize.
+        Returns 0.0 if no measurement is available (external DB without
+        sensor, or missing SQLite file).
+        """
+        # External DB sensor override
+        if self.db_sensor_id:
+            val = self._get_float(self.db_sensor_id)
+            if val > 0:
+                _LOGGER.debug(
+                    "HAGHS: Using external DB sensor '%s' — %.1f MB",
+                    self.db_sensor_id,
+                    val,
+                )
+                return val
+            _LOGGER.debug(
+                "HAGHS: External DB sensor '%s' returned %.1f — skipping DB penalty",
+                self.db_sensor_id,
+                val,
+            )
+            return 0.0
+
+        # Default: local SQLite file
+        try:
+            size_bytes: int = await self.hass.async_add_executor_job(
+                os.path.getsize, self._db_path
+            )
+            return size_bytes / (1024 * 1024)
+        except OSError:
+            _LOGGER.debug(
+                "HAGHS: SQLite DB not found at %s — assuming external database",
+                self._db_path,
+            )
+            return 0.0
+
+    def _calc_updates(self) -> tuple[int, int, int, int, list[str]]:
+        """Calculate backup, update and core-lag penalties.
+
+        Returns (p_backup, update_count, p_updates, p_core_lag, pending_updates).
+        Update entities with the ignore label are excluded from counting and penalties.
+        Core lag threshold: >= 3 months behind.
+        """
+        backup_state = self.hass.states.get("binary_sensor.backups_stale")
+        p_backup = 30 if (backup_state and backup_state.state == "on") else 0
+
+        ent_reg = er.async_get(self.hass)
+        update_count = 0
+        pending_updates: list[str] = []
+
+        for state in self.hass.states.async_all():
+            if state.domain == "update" and state.state == "on":
+                # Check ignore label on update entity
+                entity_entry = ent_reg.async_get(state.entity_id)
+                if entity_entry and self.ignore_label in (entity_entry.labels or set()):
+                    continue
+                update_count += 1
+                name = state.attributes.get("friendly_name", state.entity_id)
+                pending_updates.append(name)
+
+        p_core_lag = 0
+        core_entity_id = self._detect_core_update_entity()
+        core_state = self.hass.states.get(core_entity_id) if core_entity_id else None
+        if core_state:
+            current: str | None = core_state.attributes.get("installed_version")
+            latest: str | None = core_state.attributes.get("latest_version")
+            if current and latest and "." in current and "." in latest:
+                try:
+                    cur_parts = [int(x) for x in current.split(".")[:2]]
+                    lat_parts = [int(x) for x in latest.split(".")[:2]]
+                    if ((lat_parts[0] * 12) + lat_parts[1]) - (
+                        (cur_parts[0] * 12) + cur_parts[1]
+                    ) >= 3:
+                        p_core_lag = 20
+                except (ValueError, IndexError):
+                    pass
+
+        p_updates = min(35, (update_count * 5) + p_core_lag)
+        return p_backup, update_count, p_updates, p_core_lag, pending_updates
+
+    # ------------------------------------------------------------------
+    # Config Audit — bonus for good recorder configuration
+    # ------------------------------------------------------------------
+
+    def _calc_config_audit(self) -> int:
+        """Calculate config audit bonus based on recorder configuration.
+
+        Awards bonus points (reduces net penalty) for good practices:
+          +5  if purge_keep_days is configured
+          +5  if include/exclude entity filter is active
+        Max bonus: 10.
+        """
+        bonus = 0
+        if self.recorder_info.available:
+            if self.recorder_info.keep_days is not None:
+                bonus += 5
+            if self.recorder_info.entity_filter_active:
+                bonus += 5
+        return bonus
+
+    # ------------------------------------------------------------------
+    # Recorder info reader
+    # ------------------------------------------------------------------
+
+    def _read_recorder_info(self) -> _RecorderInfo:
+        """Read recorder configuration from hass.data.
+
+        Safe access — returns empty _RecorderInfo if recorder is not loaded
+        or not available (e.g. external database without recorder component).
+        """
+        try:
+            recorder = self.hass.data.get("recorder_instance")
+            if recorder is None:
+                _LOGGER.debug("HAGHS: Recorder instance not found in hass.data")
+                return _RecorderInfo()
+
+            keep_days = getattr(recorder, "keep_days", None)
+            entity_filter = getattr(recorder, "entity_filter", None)
+
+            return _RecorderInfo(
+                keep_days=keep_days,
+                entity_filter_active=entity_filter is not None,
+                available=True,
+            )
+        except Exception:
+            _LOGGER.warning(
+                "HAGHS: Failed to read recorder info — skipping",
+                exc_info=True,
+            )
+            return _RecorderInfo()
+
+    # ------------------------------------------------------------------
+    # Dynamic core update entity detection
+    # ------------------------------------------------------------------
+
+    def _detect_core_update_entity(self) -> str | None:
+        """Dynamically find the HA Core update entity.
+
+        Searches the update domain for an entity that represents
+        Home Assistant Core.  Works across Supervised, Docker, and K8s setups.
+
+        Detection strategy (first match wins):
+          1. entity_id contains 'home_assistant_core'
+          2. title attribute contains 'Home Assistant Core' (case-insensitive)
+        """
+        for state in self.hass.states.async_all("update"):
+            eid = state.entity_id
+            if "home_assistant_core" in eid:
+                return eid
+            title = state.attributes.get("title", "")
+            if title and "home assistant core" in title.lower():
+                return eid
+        _LOGGER.debug("HAGHS: No HA Core update entity found — core lag check skipped")
+        return None
+
+    # ------------------------------------------------------------------
+    # Recommendations builder
+    # ------------------------------------------------------------------
+
+    def _build_recommendations(
+        self,
+        hw: _HardwareResult,
+        app: _ApplicationResult,
+    ) -> list[str]:
+        """Build human-readable recommendation strings.
+
+        All templates are defined in const.py (mirrored in strings.json)
+        so translators can find and override them.
+        """
+        advice: list[str] = []
+        if hw.p_cpu > 0:
+            advice.append(REC_CPU_LOAD.format(cpu_pct=hw.cpu))
+        if hw.p_ram > 0:
+            advice.append(REC_RAM_PRESSURE.format(ram_pct=hw.ram))
+        if hw.p_io > 0:
+            advice.append(REC_IO_PRESSURE.format(io_pct=hw.io))
+        if (
+            self._storage_type in ("sd-card", "emmc")
+            and hw.disk_free < 5 * _GB
+            and hw.disk_total > 0
+        ):
+            advice.append(
+                REC_DISK_SD_LOW.format(
+                    free_gb=hw.disk_free / _GB,
+                    storage_type=self._storage_type,
+                )
+            )
+        elif self._storage_type == "ssd" and hw.disk_total > 0:
+            free_pct = (hw.disk_free / hw.disk_total) * 100
+            if free_pct < 10:
+                advice.append(REC_DISK_SSD_LOW.format(free_gb=hw.disk_free / _GB))
+        if app.db_mb > app.db_limit_mb:
+            advice.append(
+                REC_DB_OVER_LIMIT.format(
+                    db_gb=app.db_mb / 1000,
+                    limit_gb=app.db_limit_mb / 1000,
+                )
+            )
+        if hw.p_power > 0:
+            advice.append(REC_POWER_UNSTABLE)
+        if app.p_backup > 0:
+            advice.append(REC_BACKUP_STALE)
+        if app.update_count > 0:
+            advice.append(REC_UPDATES_PENDING.format(count=app.update_count))
+        if app.p_zombie > 0:
+            advice.append(REC_ZOMBIES.format(count=app.zombie_count))
+        if app.p_core_lag > 0:
+            advice.append(REC_CORE_LAG)
+        return advice
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_float(self, entity_id: str | None) -> float:
+        """Safely read a float value from an entity state."""
+        if not entity_id:
+            return 0.0
+        state = self.hass.states.get(entity_id)
+        if not state or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return 0.0
+        try:
+            return float(state.state)
+        except (ValueError, TypeError):
+            return 0.0

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -9,7 +9,7 @@ import math
 import os
 import re
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 import psutil
@@ -31,6 +31,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_UNREGISTERED_PREFIX,
+    BATTERY_GRACE_SECONDS,
     CONF_CPU_SENSOR,
     CONF_DB_SENSOR,
     CONF_IGNORE_LABEL,
@@ -39,6 +40,7 @@ from .const import (
     CONF_STORAGE_TYPE,
     CONF_UPDATE_INTERVAL,
     DATA_BOOT_TIME,
+    DATA_UPDATE_FIRST_SEEN,
     DEFAULT_STORAGE_TYPE,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
@@ -56,6 +58,8 @@ from .const import (
     REC_RAM_PRESSURE_PSI,
     REC_UPDATES_PENDING,
     REC_ZOMBIES,
+    UPDATE_GRACE_DAYS,
+    ZOMBIE_GRACE_SECONDS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -217,6 +221,14 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # than the latest reload. setdefault preserves an existing value.
         hass_data = hass.data.setdefault(DOMAIN, {})
         self._boot_time = hass_data.setdefault(DATA_BOOT_TIME, dt_util.utcnow())
+
+        # First-seen timestamps for pending update entities (#26). Stored in
+        # hass.data so they survive integration reloads. Reset on HA restart,
+        # which is desired: a fresh boot effectively gives all current updates
+        # a new grace window.
+        self._update_first_seen: dict[str, datetime] = hass_data.setdefault(
+            DATA_UPDATE_FIRST_SEEN, {}
+        )
 
         # Track ghost zombies (no entity-registry entry) so we warn at most
         # once per entity per coordinator instance instead of every refresh.
@@ -697,12 +709,19 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
                 continue
 
-            # Grace period: skip entities that changed < 15 min ago.
-            # last_changed values older than the recorded boot time were
-            # restored from the recorder and are not a reliable baseline,
-            # so treat boot time as the floor.
+            # Grace period: skip entities that changed less than the window
+            # ago. last_changed values older than the recorded boot time were
+            # restored from the recorder and are not a reliable baseline, so
+            # treat boot time as the floor. Battery-class entities get an
+            # extended window because Zigbee/Homematic coordinators routinely
+            # take longer than 15 minutes to re-poll them (#62).
             effective_seen = max(state.last_changed, self._boot_time)
-            if (now - effective_seen).total_seconds() < 900:
+            grace_seconds = (
+                BATTERY_GRACE_SECONDS
+                if state.attributes.get("device_class") == "battery"
+                else ZOMBIE_GRACE_SECONDS
+            )
+            if (now - effective_seen).total_seconds() < grace_seconds:
                 continue
 
             entity_id = state.entity_id
@@ -820,24 +839,40 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Calculate backup, update and core-lag penalties.
 
         Returns (p_backup, update_count, p_updates, p_core_lag, pending_updates).
-        Update entities with the ignore label are excluded from counting and penalties.
-        Core lag threshold: >= 3 months behind.
+        Update entities with the ignore label or matching an ignore pattern
+        are excluded from counting and penalties. Pending updates appear in
+        pending_updates immediately but only contribute to update_count after
+        UPDATE_GRACE_DAYS (#26). Core lag threshold: >= 3 months behind.
         """
         backup_state = self.hass.states.get("binary_sensor.backups_stale")
         p_backup = 30 if (backup_state and backup_state.state == "on") else 0
 
         ent_reg = er.async_get(self.hass)
+        now = dt_util.utcnow()
+        grace = timedelta(days=UPDATE_GRACE_DAYS)
         update_count = 0
         pending_updates: list[str] = []
+        currently_pending: set[str] = set()
 
         for state in self.hass.states.async_all():
-            if state.domain == "update" and state.state == "on":
-                entity_entry = ent_reg.async_get(state.entity_id)
-                if self._is_ignored(state.entity_id, entity_entry):
-                    continue
+            if state.domain != "update" or state.state != "on":
+                continue
+            entity_entry = ent_reg.async_get(state.entity_id)
+            if self._is_ignored(state.entity_id, entity_entry):
+                continue
+
+            currently_pending.add(state.entity_id)
+            first_seen = self._update_first_seen.setdefault(state.entity_id, now)
+            name = state.attributes.get("friendly_name", state.entity_id)
+            pending_updates.append(name)
+            if now - first_seen >= grace:
                 update_count += 1
-                name = state.attributes.get("friendly_name", state.entity_id)
-                pending_updates.append(name)
+
+        # Prune entries for updates that are no longer pending so installed
+        # updates don't keep a stale timestamp around.
+        for stale_id in list(self._update_first_seen):
+            if stale_id not in currently_pending:
+                del self._update_first_seen[stale_id]
 
         p_core_lag = 0
         core_entity_id = self._detect_core_update_entity()

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -45,13 +45,15 @@ from .const import (
     REC_ALL_CLEAR,
     REC_BACKUP_STALE,
     REC_CORE_LAG,
-    REC_CPU_LOAD,
+    REC_CPU_LOAD_CLASSIC,
+    REC_CPU_LOAD_PSI,
     REC_DB_OVER_LIMIT,
     REC_DISK_SD_LOW,
     REC_DISK_SSD_LOW,
     REC_IO_PRESSURE,
     REC_POWER_UNSTABLE,
-    REC_RAM_PRESSURE,
+    REC_RAM_PRESSURE_CLASSIC,
+    REC_RAM_PRESSURE_PSI,
     REC_UPDATES_PENDING,
     REC_ZOMBIES,
 )
@@ -126,6 +128,8 @@ class _HardwareResult:
     p_io: int = 0
     p_power: int = 0
     psi_available: bool = False
+    cpu_used_psi: bool = False
+    ram_used_psi: bool = False
 
 
 @dataclass
@@ -504,6 +508,8 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             p_io=p_io,
             p_power=p_power,
             psi_available=use_psi,
+            cpu_used_psi=psi.cpu is not None,
+            ram_used_psi=psi.memory is not None,
         )
 
     # -- CPU penalty tiers -------------------------------------------------
@@ -942,9 +948,11 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         advice: list[str] = []
         if hw.p_cpu > 0:
-            advice.append(REC_CPU_LOAD.format(cpu_pct=hw.cpu))
+            cpu_tpl = REC_CPU_LOAD_PSI if hw.cpu_used_psi else REC_CPU_LOAD_CLASSIC
+            advice.append(cpu_tpl.format(cpu_pct=hw.cpu))
         if hw.p_ram > 0:
-            advice.append(REC_RAM_PRESSURE.format(ram_pct=hw.ram))
+            ram_tpl = REC_RAM_PRESSURE_PSI if hw.ram_used_psi else REC_RAM_PRESSURE_CLASSIC
+            advice.append(ram_tpl.format(ram_pct=hw.ram))
         if hw.p_io > 0:
             advice.append(REC_IO_PRESSURE.format(io_pct=hw.io))
         if (

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -31,7 +31,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_UNREGISTERED_PREFIX,
-    BATTERY_GRACE_SECONDS,
+    CONF_BATTERY_GRACE_MINUTES,
     CONF_CPU_SENSOR,
     CONF_DB_SENSOR,
     CONF_IGNORE_LABELS,
@@ -39,10 +39,13 @@ from .const import (
     CONF_RAM_SENSOR,
     CONF_STORAGE_TYPE,
     CONF_UPDATE_INTERVAL,
+    CONF_ZOMBIE_GRACE_MINUTES,
     DATA_BOOT_TIME,
     DATA_UPDATE_FIRST_SEEN,
+    DEFAULT_BATTERY_GRACE_MINUTES,
     DEFAULT_STORAGE_TYPE,
     DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_ZOMBIE_GRACE_MINUTES,
     DOMAIN,
     REC_ALL_CLEAR,
     REC_BACKUP_STALE,
@@ -59,7 +62,6 @@ from .const import (
     REC_UPDATES_PENDING,
     REC_ZOMBIES,
     UPDATE_GRACE_DAYS,
-    ZOMBIE_GRACE_SECONDS,
     ZOMBIE_LIST_CAP,
 )
 
@@ -230,6 +232,16 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             opts.get(CONF_IGNORE_PATTERNS)
         )
         self._storage_type: str = opts.get(CONF_STORAGE_TYPE, DEFAULT_STORAGE_TYPE)
+
+        # Grace windows are user-configurable in the Options Flow. Both
+        # values are stored in minutes for friendlier UX, multiplied to
+        # seconds here once at init so the hot path stays cheap.
+        self._zombie_grace_seconds: int = (
+            int(opts.get(CONF_ZOMBIE_GRACE_MINUTES, DEFAULT_ZOMBIE_GRACE_MINUTES)) * 60
+        )
+        self._battery_grace_seconds: int = (
+            int(opts.get(CONF_BATTERY_GRACE_MINUTES, DEFAULT_BATTERY_GRACE_MINUTES)) * 60
+        )
 
         # Paths for auto-detection (resolved once at init)
         self._db_path: str = hass.config.path(HA_DB_NAME)
@@ -757,14 +769,14 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Grace period: skip entities that changed less than the window
             # ago. last_changed values older than the recorded boot time were
             # restored from the recorder and are not a reliable baseline, so
-            # treat boot time as the floor. Battery-class entities get an
-            # extended window because Zigbee/Homematic coordinators routinely
-            # take longer than 15 minutes to re-poll them (#62).
+            # treat boot time as the floor. Battery-class entities use a
+            # separate, typically longer window (configurable in the Options
+            # Flow, defaults are 15 min for general and 60 min for battery).
             effective_seen = max(state.last_changed, self._boot_time)
             grace_seconds = (
-                BATTERY_GRACE_SECONDS
+                self._battery_grace_seconds
                 if state.attributes.get("device_class") == "battery"
-                else ZOMBIE_GRACE_SECONDS
+                else self._zombie_grace_seconds
             )
             if (now - effective_seen).total_seconds() < grace_seconds:
                 continue

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -383,9 +383,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if psi.io is not None:
             hardware_final = max(
                 0.0,
-                min(
-                    100.0, (score_cpu + score_ram + score_io + score_disk) / 4 - p_power
-                ),
+                min(100.0, (score_cpu + score_ram + score_io + score_disk) / 4 - p_power),
             )
         else:
             hardware_final = max(
@@ -510,9 +508,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_get_disk_usage(self) -> Any | None:
         """Return full psutil disk_usage result, or None on failure."""
         try:
-            return await self.hass.async_add_executor_job(
-                psutil.disk_usage, self._config_dir
-            )
+            return await self.hass.async_add_executor_job(psutil.disk_usage, self._config_dir)
         except (OSError, FileNotFoundError):
             _LOGGER.warning(
                 "HAGHS: Could not read disk usage for %s — assuming healthy",
@@ -536,9 +532,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         db_mb, p_db, db_limit_mb = await self._async_calc_maintenance()
 
         # D. UPDATES
-        p_backup, update_count, p_updates, p_core_lag, pending_updates = (
-            self._calc_updates()
-        )
+        p_backup, update_count, p_updates, p_core_lag, pending_updates = self._calc_updates()
 
         # E. CONFIG AUDIT — bonus for good recorder configuration
         config_bonus = self._calc_config_audit()
@@ -547,13 +541,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             0,
             min(
                 100,
-                100
-                - p_zombie
-                - p_integration
-                - p_backup
-                - p_updates
-                - p_db
-                + config_bonus,
+                100 - p_zombie - p_integration - p_backup - p_updates - p_db + config_bonus,
             ),
         )
 
@@ -691,9 +679,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Default: local SQLite file
         try:
-            size_bytes: int = await self.hass.async_add_executor_job(
-                os.path.getsize, self._db_path
-            )
+            size_bytes: int = await self.hass.async_add_executor_job(os.path.getsize, self._db_path)
             return size_bytes / (1024 * 1024)
         except OSError:
             _LOGGER.debug(

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import logging
 import math
 import os
@@ -33,6 +34,7 @@ from .const import (
     CONF_CPU_SENSOR,
     CONF_DB_SENSOR,
     CONF_IGNORE_LABEL,
+    CONF_IGNORE_PATTERNS,
     CONF_RAM_SENSOR,
     CONF_STORAGE_TYPE,
     CONF_UPDATE_INTERVAL,
@@ -152,6 +154,29 @@ class _RecorderInfo:
     available: bool = False
 
 
+def _compile_patterns(raw: list[str] | None) -> list[re.Pattern[str]]:
+    """Translate user-supplied glob patterns to compiled regex objects.
+
+    Invalid patterns are dropped with a warning rather than raising — a single
+    typo must not break zombie or update detection for the whole instance.
+    """
+    if not raw:
+        return []
+    compiled: list[re.Pattern[str]] = []
+    for pattern in raw:
+        if not pattern:
+            continue
+        try:
+            compiled.append(re.compile(fnmatch.translate(pattern)))
+        except re.error as err:
+            _LOGGER.warning(
+                "HAGHS: Invalid ignore pattern %r (%s) — skipping",
+                pattern,
+                err,
+            )
+    return compiled
+
+
 class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator that calculates the Global Health Score."""
 
@@ -171,6 +196,9 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.ram_id: str | None = opts.get(CONF_RAM_SENSOR)
         self.db_sensor_id: str | None = opts.get(CONF_DB_SENSOR) or None
         self.ignore_label: str | None = opts.get(CONF_IGNORE_LABEL)
+        self._ignore_patterns: list[re.Pattern[str]] = _compile_patterns(
+            opts.get(CONF_IGNORE_PATTERNS)
+        )
         self._storage_type: str = opts.get(CONF_STORAGE_TYPE, DEFAULT_STORAGE_TYPE)
 
         # Paths for auto-detection (resolved once at init)
@@ -206,6 +234,35 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _async_registries_ready(self, _event: Event) -> None:
         """Mark registries as loaded once HA finishes startup."""
         self._registries_ready = True
+
+    def _is_ignored(
+        self,
+        entity_id: str,
+        entity_entry: er.RegistryEntry | None,
+    ) -> bool:
+        """Return True if an entity should be excluded from health checks.
+
+        Three exclusion sources, checked in cheapest-first order:
+          1. Glob patterns on entity_id (no registry lookup required)
+          2. ignore_label on the entity's registry entry
+          3. ignore_label on the entity's device
+        """
+        if self._ignore_patterns and any(p.match(entity_id) for p in self._ignore_patterns):
+            return True
+
+        if self.ignore_label is None or entity_entry is None:
+            return False
+
+        if self.ignore_label in (entity_entry.labels or set()):
+            return True
+
+        if entity_entry.device_id:
+            dev_reg = dr.async_get(self.hass)
+            device_entry = dev_reg.async_get(entity_entry.device_id)
+            if device_entry and self.ignore_label in (device_entry.labels or set()):
+                return True
+
+        return False
 
     # ------------------------------------------------------------------
     # Main update — orchestrates sub-calculations with safety net
@@ -611,7 +668,6 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return [], 0, 0
 
         ent_reg = er.async_get(self.hass)
-        dev_reg = dr.async_get(self.hass)
         now = dt_util.utcnow()
         zombie_list: list[str] = []
         # Denominator only counts entities that could ever be flagged as zombies,
@@ -638,33 +694,26 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if "integration_health" in entity_id:
                 continue
 
-            is_ignored = False
             entity_entry = ent_reg.async_get(entity_id)
-            if entity_entry and self.ignore_label in (entity_entry.labels or set()):
-                is_ignored = True
+            if self._is_ignored(entity_id, entity_entry):
+                continue
 
-            if not is_ignored and entity_entry and entity_entry.device_id:
-                device_entry = dev_reg.async_get(entity_entry.device_id)
-                if device_entry and self.ignore_label in (device_entry.labels or set()):
-                    is_ignored = True
-
-            if not is_ignored:
-                if entity_entry is None:
-                    # Ghost zombie: exists in the state machine but has no
-                    # entity registry entry, so it cannot be managed in the
-                    # HA UI. Surface it explicitly and warn once per id (#6).
-                    if entity_id not in self._logged_ghost_entities:
-                        _LOGGER.warning(
-                            "HAGHS: Detected unregistered zombie entity '%s'. "
-                            "It exists in the state machine but has no entity "
-                            "registry entry, so it cannot be managed via the "
-                            "HA UI. Check the integration that created it.",
-                            entity_id,
-                        )
-                        self._logged_ghost_entities.add(entity_id)
-                    zombie_list.append(f"{ATTR_UNREGISTERED_PREFIX}{entity_id}")
-                else:
-                    zombie_list.append(entity_id)
+            if entity_entry is None:
+                # Ghost zombie: exists in the state machine but has no entity
+                # registry entry, so it cannot be managed in the HA UI.
+                # Surface it explicitly and warn once per id (#6).
+                if entity_id not in self._logged_ghost_entities:
+                    _LOGGER.warning(
+                        "HAGHS: Detected unregistered zombie entity '%s'. "
+                        "It exists in the state machine but has no entity "
+                        "registry entry, so it cannot be managed via the "
+                        "HA UI. Check the integration that created it.",
+                        entity_id,
+                    )
+                    self._logged_ghost_entities.add(entity_id)
+                zombie_list.append(f"{ATTR_UNREGISTERED_PREFIX}{entity_id}")
+            else:
+                zombie_list.append(entity_id)
 
         zombie_count = len(zombie_list)
 
@@ -768,9 +817,8 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         for state in self.hass.states.async_all():
             if state.domain == "update" and state.state == "on":
-                # Check ignore label on update entity
                 entity_entry = ent_reg.async_get(state.entity_id)
-                if entity_entry and self.ignore_label in (entity_entry.labels or set()):
+                if self._is_ignored(state.entity_id, entity_entry):
                     continue
                 update_count += 1
                 name = state.attributes.get("friendly_name", state.entity_id)

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -574,10 +574,15 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         dev_reg = dr.async_get(self.hass)
         now = dt_util.utcnow()
         zombie_list: list[str] = []
+        # Denominator only counts entities that could ever be flagged as zombies,
+        # so an instance with many automations/scripts/etc. is not artificially
+        # diluted. Counted in the same pass as detection.
+        zombie_domain_total = 0
 
         for state in self.hass.states.async_all():
             if state.domain not in ZOMBIE_DOMAINS:
                 continue
+            zombie_domain_total += 1
             if state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
                 continue
 
@@ -604,11 +609,11 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         zombie_count = len(zombie_list)
 
-        # Ratio-based penalty: percentage of zombies relative to total entities
-        # Factor 7 + ceil ensures zombies are visible on all instance sizes
-        total_entities = len(self.hass.states.async_all())
-        if total_entities > 0:
-            zombie_ratio_pct = (zombie_count / total_entities) * 100
+        # Ratio-based penalty: percentage of zombies relative to entities in
+        # ZOMBIE_DOMAINS only. Factor 7 + ceil ensures zombies are visible on
+        # all instance sizes.
+        if zombie_domain_total > 0:
+            zombie_ratio_pct = (zombie_count / zombie_domain_total) * 100
             p_zombie = min(20, math.ceil(zombie_ratio_pct * 7))
         else:
             p_zombie = 0

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -258,11 +258,22 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     ) -> bool:
         """Return True if an entity should be excluded from health checks.
 
-        Three exclusion sources, checked in cheapest-first order:
-          1. Glob patterns on entity_id (no registry lookup required)
-          2. ignore_label on the entity's registry entry
-          3. ignore_label on the entity's device
+        Four exclusion sources, checked in cheapest-first order:
+          1. Disabled in the entity registry (user clicked "Disable entity"
+             or the integration disabled it). Clear user-intent signal that
+             takes precedence over the other checks.
+          2. Glob patterns on entity_id (no registry lookup required)
+          3. ignore_label on the entity's registry entry
+          4. ignore_label on the entity's device
+
+        Note: ``hidden_by`` is intentionally not treated as ignore. Hidden
+        entities are still functional; the user only hid them from
+        auto-generated dashboards. To exclude them from HAGHS the user
+        should disable the entity or apply the ignore label.
         """
+        if entity_entry is not None and entity_entry.disabled_by is not None:
+            return True
+
         if self._ignore_patterns and any(p.match(entity_id) for p in self._ignore_patterns):
             return True
 

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_RAM_SENSOR,
     CONF_STORAGE_TYPE,
     CONF_UPDATE_INTERVAL,
+    DATA_BOOT_TIME,
     DEFAULT_STORAGE_TYPE,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
@@ -173,6 +174,12 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Recorder info — populated on each update cycle (Phase 3 ready)
         self.recorder_info: _RecorderInfo = _RecorderInfo()
+
+        # Boot-time baseline for zombie grace. Stored in hass.data so it
+        # survives integration reloads and reflects the actual HA boot rather
+        # than the latest reload. setdefault preserves an existing value.
+        hass_data = hass.data.setdefault(DOMAIN, {})
+        self._boot_time = hass_data.setdefault(DATA_BOOT_TIME, dt_util.utcnow())
 
     # ------------------------------------------------------------------
     # Main update — orchestrates sub-calculations with safety net
@@ -586,8 +593,12 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
                 continue
 
-            # Grace period: skip entities that changed < 15 min ago
-            if (now - state.last_changed).total_seconds() < 900:
+            # Grace period: skip entities that changed < 15 min ago.
+            # last_changed values older than the recorded boot time were
+            # restored from the recorder and are not a reliable baseline,
+            # so treat boot time as the floor.
+            effective_seen = max(state.last_changed, self._boot_time)
+            if (now - effective_seen).total_seconds() < 900:
                 continue
 
             entity_id = state.entity_id

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -300,6 +300,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
         advice = self._build_recommendations(hw, app)
+        rec_flags = self._build_rec_flags(hw, app)
 
         return {
             "global_score": int(global_score),
@@ -313,6 +314,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "recorder_filter_active": self.recorder_info.entity_filter_active,
             "pending_updates": app.pending_updates,
             "recommendations": ("\n".join(advice) if advice else REC_ALL_CLEAR),
+            **rec_flags,
         }
 
     async def _safe_calc(
@@ -955,21 +957,15 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             advice.append(ram_tpl.format(ram_pct=hw.ram))
         if hw.p_io > 0:
             advice.append(REC_IO_PRESSURE.format(io_pct=hw.io))
-        if (
-            self._storage_type in ("sd-card", "emmc")
-            and hw.disk_free < 5 * _GB
-            and hw.disk_total > 0
-        ):
+        if self._is_disk_low_sd(hw):
             advice.append(
                 REC_DISK_SD_LOW.format(
                     free_gb=hw.disk_free / _GB,
                     storage_type=self._storage_type,
                 )
             )
-        elif self._storage_type == "ssd" and hw.disk_total > 0:
-            free_pct = (hw.disk_free / hw.disk_total) * 100
-            if free_pct < 10:
-                advice.append(REC_DISK_SSD_LOW.format(free_gb=hw.disk_free / _GB))
+        elif self._is_disk_low_ssd(hw):
+            advice.append(REC_DISK_SSD_LOW.format(free_gb=hw.disk_free / _GB))
         if app.db_mb > app.db_limit_mb:
             advice.append(
                 REC_DB_OVER_LIMIT.format(
@@ -988,6 +984,44 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if app.p_core_lag > 0:
             advice.append(REC_CORE_LAG)
         return advice
+
+    def _is_disk_low_sd(self, hw: _HardwareResult) -> bool:
+        """Return True if the SD-card / eMMC low-disk threshold is met."""
+        return (
+            self._storage_type in ("sd-card", "emmc")
+            and hw.disk_total > 0
+            and hw.disk_free < 5 * _GB
+        )
+
+    def _is_disk_low_ssd(self, hw: _HardwareResult) -> bool:
+        """Return True if the SSD low-disk threshold (<10 % free) is met."""
+        if self._storage_type != "ssd" or hw.disk_total <= 0:
+            return False
+        return (hw.disk_free / hw.disk_total) * 100 < 10
+
+    def _build_rec_flags(
+        self,
+        hw: _HardwareResult,
+        app: _ApplicationResult,
+    ) -> dict[str, bool]:
+        """Mirror _build_recommendations as a flat dict of boolean attributes.
+
+        Dashboards and external integrations should read these via state_attr
+        instead of parsing the rendered recommendations string. Keep the keys
+        in sync with REC_FLAG_KEYS in const.py.
+        """
+        return {
+            "rec_cpu_load": hw.p_cpu > 0,
+            "rec_ram_pressure": hw.p_ram > 0,
+            "rec_io_pressure": hw.p_io > 0,
+            "rec_disk_low": self._is_disk_low_sd(hw) or self._is_disk_low_ssd(hw),
+            "rec_db_over_limit": app.db_mb > app.db_limit_mb,
+            "rec_power_unstable": hw.p_power > 0,
+            "rec_backup_stale": app.p_backup > 0,
+            "rec_updates_pending": app.update_count > 0,
+            "rec_zombie": app.zombie_count > 0,
+            "rec_core_lag": app.p_core_lag > 0,
+        }
 
     # ------------------------------------------------------------------
     # Helpers

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -60,6 +60,7 @@ from .const import (
     REC_ZOMBIES,
     UPDATE_GRACE_DAYS,
     ZOMBIE_GRACE_SECONDS,
+    ZOMBIE_LIST_CAP,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -83,18 +84,38 @@ PSI_IO_PATH = "/proc/pressure/io"
 # Regex to extract 'some avg10=X.XX' from PSI files
 _PSI_SOME_AVG10_RE = re.compile(r"some\s+avg10=(\d+\.?\d*)")
 
-# Domains to check for zombie entities
+# Domains to check for zombie entities.
+#
+# Selection rule: any domain whose entities represent a physical device or
+# integration channel whose `unavailable` / `unknown` state signals a real
+# health problem. Helpers (input_*, counter, timer), user-defined logic
+# (automation, script, scene), HA-internal entities (person, zone, sun) and
+# domains whose default state is `unknown` until first interaction (button,
+# event) are intentionally excluded so they cannot trigger false positives.
 ZOMBIE_DOMAINS: frozenset[str] = frozenset(
     [
-        "sensor",
+        "alarm_control_panel",
         "binary_sensor",
-        "switch",
-        "light",
-        "fan",
-        "climate",
-        "media_player",
-        "vacuum",
         "camera",
+        "climate",
+        "cover",
+        "device_tracker",
+        "fan",
+        "humidifier",
+        "lawn_mower",
+        "light",
+        "lock",
+        "media_player",
+        "number",
+        "remote",
+        "select",
+        "sensor",
+        "siren",
+        "switch",
+        "text",
+        "vacuum",
+        "valve",
+        "water_heater",
     ]
 )
 
@@ -143,6 +164,7 @@ class _ApplicationResult:
     app_score: int = 100
     zombie_count: int = 0
     zombie_list: list[str] = field(default_factory=list)
+    zombie_per_domain: dict[str, int] = field(default_factory=dict)
     db_mb: float = 0.0
     db_limit_mb: float = 1000.0
     update_count: int = 0
@@ -338,6 +360,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "application_score": app.app_score,
             "zombie_count": app.zombie_count,
             "zombie_entities": app.zombie_list,
+            "zombie_count_per_domain": app.zombie_per_domain,
             "db_size_mb": round(app.db_mb, 1),
             "psi_available": hw.psi_available,
             "recorder_keep_days": self.recorder_info.keep_days,
@@ -651,7 +674,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_calc_application(self) -> _ApplicationResult:
         """Calculate the application pillar score."""
         # A. ZOMBIES
-        zombie_list, p_zombie, zombie_count = self._calc_zombies()
+        zombie_list, p_zombie, zombie_count, zombie_per_domain = self._calc_zombies()
 
         # B. INTEGRATION HEALTH
         p_integration = self._calc_integration_health()
@@ -684,6 +707,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             app_score=app_final,
             zombie_count=zombie_count,
             zombie_list=zombie_list,
+            zombie_per_domain=zombie_per_domain,
             db_mb=db_mb,
             db_limit_mb=db_limit_mb,
             update_count=update_count,
@@ -698,23 +722,26 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # Application sub-calculations
     # ------------------------------------------------------------------
 
-    def _calc_zombies(self) -> tuple[list[str], int, int]:
+    def _calc_zombies(self) -> tuple[list[str], int, int, dict[str, int]]:
         """Detect zombie entities, respecting ignore labels and grace period.
 
-        Returns (zombie_list_capped, p_zombie, zombie_count).
-        zombie_list is capped to 20 entries for state attributes;
-        zombie_count always reflects the full number.
+        Returns (zombie_list_capped, p_zombie, zombie_count, per_domain).
+        zombie_list is capped to ZOMBIE_LIST_CAP entries because the HA
+        state machine caps an attribute payload at 16 KB; zombie_count and
+        the per_domain dict always reflect the full count so users can see
+        the true scope even when the listing is truncated.
         """
         # Defer detection until HA is fully running. Otherwise the entity
         # registry may not yet be loaded from storage and ignore labels would
         # be missing, producing false positives right after boot (#13).
         if not self._registries_ready:
             _LOGGER.debug("HAGHS: HA still starting up — deferring zombie detection")
-            return [], 0, 0
+            return [], 0, 0, {}
 
         ent_reg = er.async_get(self.hass)
         now = dt_util.utcnow()
         zombie_list: list[str] = []
+        zombie_per_domain: dict[str, int] = {}
         # Denominator only counts entities that could ever be flagged as zombies,
         # so an instance with many automations/scripts/etc. is not artificially
         # diluted. Counted in the same pass as detection.
@@ -750,6 +777,8 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self._is_ignored(entity_id, entity_entry):
                 continue
 
+            zombie_per_domain[state.domain] = zombie_per_domain.get(state.domain, 0) + 1
+
             if entity_entry is None:
                 # Ghost zombie: exists in the state machine but has no entity
                 # registry entry, so it cannot be managed in the HA UI.
@@ -778,8 +807,8 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             p_zombie = 0
 
-        # Cap the list for state attributes (count stays full)
-        return zombie_list[:20], p_zombie, zombie_count
+        # Cap the list for state attributes (count + per_domain stay full).
+        return zombie_list[:ZOMBIE_LIST_CAP], p_zombie, zombie_count, zombie_per_domain
 
     def _calc_integration_health(self) -> int:
         """Count unhealthy integrations via native ConfigEntry states.

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -13,8 +13,12 @@ from typing import Any
 
 import psutil
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import (
     device_registry as dr,
 )
@@ -180,6 +184,23 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # than the latest reload. setdefault preserves an existing value.
         hass_data = hass.data.setdefault(DOMAIN, {})
         self._boot_time = hass_data.setdefault(DATA_BOOT_TIME, dt_util.utcnow())
+
+        # Registry-race guard: if HAGHS first runs while HA is still in the
+        # 'starting' state, the entity registry (and therefore label
+        # assignments) may not yet be loaded from storage, which would cause
+        # labelled-but-unavailable entities to be misreported as zombies on
+        # the first refresh after boot.
+        self._registries_ready: bool = hass.is_running
+        if not self._registries_ready:
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED,
+                self._async_registries_ready,
+            )
+
+    @callback
+    def _async_registries_ready(self, _event: Event) -> None:
+        """Mark registries as loaded once HA finishes startup."""
+        self._registries_ready = True
 
     # ------------------------------------------------------------------
     # Main update — orchestrates sub-calculations with safety net
@@ -577,6 +598,13 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         zombie_list is capped to 20 entries for state attributes;
         zombie_count always reflects the full number.
         """
+        # Defer detection until HA is fully running. Otherwise the entity
+        # registry may not yet be loaded from storage and ignore labels would
+        # be missing, producing false positives right after boot (#13).
+        if not self._registries_ready:
+            _LOGGER.debug("HAGHS: HA still starting up — deferring zombie detection")
+            return [], 0, 0
+
         ent_reg = er.async_get(self.hass)
         dev_reg = dr.async_get(self.hass)
         now = dt_util.utcnow()

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -34,7 +34,7 @@ from .const import (
     BATTERY_GRACE_SECONDS,
     CONF_CPU_SENSOR,
     CONF_DB_SENSOR,
-    CONF_IGNORE_LABEL,
+    CONF_IGNORE_LABELS,
     CONF_IGNORE_PATTERNS,
     CONF_RAM_SENSOR,
     CONF_STORAGE_TYPE,
@@ -203,7 +203,7 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.cpu_id: str | None = opts.get(CONF_CPU_SENSOR)
         self.ram_id: str | None = opts.get(CONF_RAM_SENSOR)
         self.db_sensor_id: str | None = opts.get(CONF_DB_SENSOR) or None
-        self.ignore_label: str | None = opts.get(CONF_IGNORE_LABEL)
+        self.ignore_labels: list[str] = list(opts.get(CONF_IGNORE_LABELS) or [])
         self._ignore_patterns: list[re.Pattern[str]] = _compile_patterns(
             opts.get(CONF_IGNORE_PATTERNS)
         )
@@ -263,13 +263,17 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
              or the integration disabled it). Clear user-intent signal that
              takes precedence over the other checks.
           2. Glob patterns on entity_id (no registry lookup required)
-          3. ignore_label on the entity's registry entry
-          4. ignore_label on the entity's device
+          3. Any of the configured ignore labels on the entity's registry entry
+          4. Any of the configured ignore labels on the entity's device
 
         Note: ``hidden_by`` is intentionally not treated as ignore. Hidden
         entities are still functional; the user only hid them from
         auto-generated dashboards. To exclude them from HAGHS the user
-        should disable the entity or apply the ignore label.
+        should disable the entity or apply one of the ignore labels.
+
+        Multiple ignore labels can be configured. Toggling them on/off at
+        runtime is done via Home Assistant's native ``label.assign`` and
+        ``label.remove`` service actions, not via a HAGHS-specific service.
         """
         if entity_entry is not None and entity_entry.disabled_by is not None:
             return True
@@ -277,17 +281,20 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._ignore_patterns and any(p.match(entity_id) for p in self._ignore_patterns):
             return True
 
-        if self.ignore_label is None or entity_entry is None:
+        if not self.ignore_labels or entity_entry is None:
             return False
 
-        if self.ignore_label in (entity_entry.labels or set()):
+        entity_labels = entity_entry.labels or set()
+        if any(label in entity_labels for label in self.ignore_labels):
             return True
 
         if entity_entry.device_id:
             dev_reg = dr.async_get(self.hass)
             device_entry = dev_reg.async_get(entity_entry.device_id)
-            if device_entry and self.ignore_label in (device_entry.labels or set()):
-                return True
+            if device_entry:
+                device_labels = device_entry.labels or set()
+                if any(label in device_labels for label in self.ignore_labels):
+                    return True
 
         return False
 

--- a/custom_components/haghs/coordinator.py
+++ b/custom_components/haghs/coordinator.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import CoreState, Event, HomeAssistant, callback
 from homeassistant.helpers import (
     device_registry as dr,
 )
@@ -201,6 +201,10 @@ def _compile_patterns(raw: list[str] | None) -> list[re.Pattern[str]]:
         try:
             compiled.append(re.compile(fnmatch.translate(pattern)))
         except re.error as err:
+            # Defense-in-depth: fnmatch.translate escapes most malformed
+            # glob input (e.g. unclosed character classes) so re.compile
+            # rarely raises in practice, but we keep the guard in case
+            # CPython's translation rules change in a future release.
             _LOGGER.warning(
                 "HAGHS: Invalid ignore pattern %r (%s) — skipping",
                 pattern,
@@ -273,7 +277,11 @@ class HaghsDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # assignments) may not yet be loaded from storage, which would cause
         # labelled-but-unavailable entities to be misreported as zombies on
         # the first refresh after boot.
-        self._registries_ready: bool = hass.is_running
+        #
+        # Use `state == CoreState.running` instead of `hass.is_running`, which
+        # returns True for both `starting` and `running` and would defeat the
+        # deferral during the startup window we actually care about (#13).
+        self._registries_ready: bool = hass.state == CoreState.running
         if not self._registries_ready:
             hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_STARTED,

--- a/custom_components/haghs/repairs.py
+++ b/custom_components/haghs/repairs.py
@@ -1,0 +1,61 @@
+import voluptuous as vol
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .config_flow import FALLBACK_SENSORS_SCHEMA
+from .const import IssueIds
+
+
+class MissingFallbackSensorRepairFlow(RepairsFlow):
+    """Repair flow for invalid config due to missing CPU/RAM fallbacks."""
+
+    def __init__(self, entry_id: str) -> None:
+        """Initialize repair flow."""
+        super().__init__()
+        self._entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the repair form."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            return self.async_abort(reason="config_entry_missing")
+
+        if user_input is not None:
+            options = dict(entry.options)
+            options.update(user_input)
+            self.hass.config_entries.async_update_entry(entry, options=options)
+            self.hass.config_entries.async_schedule_reload(entry.entry_id)
+            return self.async_create_entry(data={})
+
+        schema = vol.Schema(
+            schema={
+                vol.Required(sensor): selector
+                for sensor, selector in FALLBACK_SENSORS_SCHEMA.items()
+            }
+        )
+        current = {**entry.data, **entry.options}
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=self.add_suggested_values_to_schema(schema, current),
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    if issue_id == IssueIds.FALLBACK_MISSING:
+        return MissingFallbackSensorRepairFlow(data["entry_id"])

--- a/custom_components/haghs/sensor.py
+++ b/custom_components/haghs/sensor.py
@@ -1,4 +1,5 @@
 """HAGHS Sensor — CoordinatorEntity backed by HaghsDataUpdateCoordinator."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/custom_components/haghs/sensor.py
+++ b/custom_components/haghs/sensor.py
@@ -57,6 +57,7 @@ class HaghsSensor(CoordinatorEntity[HaghsDataUpdateCoordinator], SensorEntity):
             "application_score": data["application_score"],
             "zombie_count": data["zombie_count"],
             "zombie_entities": data["zombie_entities"],
+            "zombie_count_per_domain": data["zombie_count_per_domain"],
             "db_size_mb": data["db_size_mb"],
             "psi_available": data["psi_available"],
             "recorder_keep_days": data["recorder_keep_days"],

--- a/custom_components/haghs/sensor.py
+++ b/custom_components/haghs/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import HaghsDataUpdateCoordinator
-from .const import DEFAULT_NAME, DOMAIN
+from .const import DEFAULT_NAME, DOMAIN, REC_FLAG_KEYS
 
 
 async def async_setup_entry(
@@ -63,4 +63,5 @@ class HaghsSensor(CoordinatorEntity[HaghsDataUpdateCoordinator], SensorEntity):
             "recorder_filter_active": data["recorder_filter_active"],
             "pending_updates": data["pending_updates"],
             "recommendations": data["recommendations"],
+            **{k: data[k] for k in REC_FLAG_KEYS},
         }

--- a/custom_components/haghs/sensor.py
+++ b/custom_components/haghs/sensor.py
@@ -10,8 +10,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import HaghsDataUpdateCoordinator
 from .const import DEFAULT_NAME, DOMAIN, REC_FLAG_KEYS
+from .coordinator import HaghsDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/custom_components/haghs/strings.json
+++ b/custom_components/haghs/strings.json
@@ -12,11 +12,38 @@
           "db_sensor": "Database size sensor (optional)"
         },
         "data_description": {
-          "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
-          "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
+          "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
+          "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
           "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size')."
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "fallback_missing": {
+      "message": "PSI is unavailable, and CPU and RAM fallback sensors are not configured."
+    }
+  },
+  "issues": {
+    "fallback_missing": {
+      "title": "PSI is unavailable and fallback sensors are missing",
+      "description": "HAGHS cannot start because Linux PSI data is unavailable and CPU/RAM fallback sensors are not configured. Provide both sensors to recover without restarting Home Assistant.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Configure CPU and RAM fallback sensors",
+            "description": "Select both fallback sensors and submit to update this integration entry.",
+            "data": {
+              "cpu_sensor": "CPU usage sensor",
+              "ram_sensor": "RAM usage sensor"
+            },
+            "data_description": {
+              "cpu_sensor": "Select the sensor that reports CPU usage in percent.",
+              "ram_sensor": "Select the sensor that reports memory usage in percent."
+            }
+          }
         }
       }
     }
@@ -35,8 +62,8 @@
           "update_interval": "Update interval"
         },
         "data_description": {
-          "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
-          "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
+          "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
+          "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
           "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size').",

--- a/custom_components/haghs/strings.json
+++ b/custom_components/haghs/strings.json
@@ -8,7 +8,7 @@
           "cpu_sensor": "CPU usage sensor",
           "ram_sensor": "RAM usage sensor",
           "storage_type": "Storage type",
-          "ignore_label": "Ignore label",
+          "ignore_labels": "Ignore labels",
           "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)"
         },
@@ -16,7 +16,7 @@
           "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
           "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
-          "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
+          "ignore_labels": "Select one or more labels from your Home Assistant labels. Entities and devices carrying any of these labels are excluded from zombie detection and update penalties. Toggle exclusions dynamically from an automation by calling Home Assistant's native 'label.assign' and 'label.remove' service actions (e.g. switch a 'vacation' label on while you are away). Create the labels first under Settings → Labels if they do not exist yet.",
           "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size')."
         }
@@ -58,7 +58,7 @@
           "cpu_sensor": "CPU usage sensor",
           "ram_sensor": "RAM usage sensor",
           "storage_type": "Storage type",
-          "ignore_label": "Ignore label",
+          "ignore_labels": "Ignore labels",
           "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)",
           "update_interval": "Update interval"
@@ -67,7 +67,7 @@
           "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
           "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
-          "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
+          "ignore_labels": "Select one or more labels from your Home Assistant labels. Entities and devices carrying any of these labels are excluded from zombie detection and update penalties. Toggle exclusions dynamically from an automation by calling Home Assistant's native 'label.assign' and 'label.remove' service actions (e.g. switch a 'vacation' label on while you are away). Create the labels first under Settings → Labels if they do not exist yet.",
           "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size').",
           "update_interval": "How often HAGHS recalculates the health score, in seconds. Lower values mean faster updates but slightly more CPU usage. Default: 60 seconds."

--- a/custom_components/haghs/strings.json
+++ b/custom_components/haghs/strings.json
@@ -61,7 +61,9 @@
           "ignore_labels": "Ignore labels",
           "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)",
-          "update_interval": "Update interval"
+          "update_interval": "Update interval",
+          "zombie_grace_minutes": "Zombie grace period (minutes)",
+          "battery_grace_minutes": "Battery-class grace period (minutes)"
         },
         "data_description": {
           "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
@@ -70,7 +72,9 @@
           "ignore_labels": "Select one or more labels from your Home Assistant labels. Entities and devices carrying any of these labels are excluded from zombie detection and update penalties. Toggle exclusions dynamically from an automation by calling Home Assistant's native 'label.assign' and 'label.remove' service actions (e.g. switch a 'vacation' label on while you are away). Create the labels first under Settings → Labels if they do not exist yet.",
           "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size').",
-          "update_interval": "How often HAGHS recalculates the health score, in seconds. Lower values mean faster updates but slightly more CPU usage. Default: 60 seconds."
+          "update_interval": "How often HAGHS recalculates the health score, in seconds. Lower values mean faster updates but slightly more CPU usage. Default: 60 seconds.",
+          "zombie_grace_minutes": "How long an entity must stay in 'unavailable' or 'unknown' before HAGHS counts it as a zombie. Allowed range: 1 to 240 minutes. Lower values make detection more aggressive (more false positives from briefly-offline devices). Higher values mask short outages but let real failures linger. Default: 15 minutes.",
+          "battery_grace_minutes": "Extended grace period specifically for entities with 'device_class: battery'. Zigbee and Homematic radios routinely take longer than the regular window to re-poll battery devices, so flagging them as zombies after only 15 minutes produces false positives. Allowed range: 1 to 240 minutes. If you set this lower than the regular grace, it effectively disables the extension. Default: 60 minutes."
         }
       }
     }

--- a/custom_components/haghs/strings.json
+++ b/custom_components/haghs/strings.json
@@ -29,12 +29,11 @@
   "issues": {
     "fallback_missing": {
       "title": "PSI is unavailable and fallback sensors are missing",
-      "description": "HAGHS cannot start because Linux PSI data is unavailable and CPU/RAM fallback sensors are not configured. Provide both sensors to recover without restarting Home Assistant.",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Configure CPU and RAM fallback sensors",
-            "description": "Select both fallback sensors and submit to update this integration entry.",
+            "description": "HAGHS cannot start because Linux PSI data is unavailable and CPU/RAM fallback sensors are not configured. Select both sensors below and submit to recover without restarting Home Assistant.",
             "data": {
               "cpu_sensor": "CPU usage sensor",
               "ram_sensor": "RAM usage sensor"

--- a/custom_components/haghs/strings.json
+++ b/custom_components/haghs/strings.json
@@ -9,6 +9,7 @@
           "ram_sensor": "RAM usage sensor",
           "storage_type": "Storage type",
           "ignore_label": "Ignore label",
+          "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)"
         },
         "data_description": {
@@ -16,6 +17,7 @@
           "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
           "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
+          "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size')."
         }
       }
@@ -57,6 +59,7 @@
           "ram_sensor": "RAM usage sensor",
           "storage_type": "Storage type",
           "ignore_label": "Ignore label",
+          "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)",
           "update_interval": "Update interval"
         },
@@ -65,6 +68,7 @@
           "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
           "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
+          "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size').",
           "update_interval": "How often HAGHS recalculates the health score, in seconds. Lower values mean faster updates but slightly more CPU usage. Default: 60 seconds."
         }

--- a/custom_components/haghs/translations/en.json
+++ b/custom_components/haghs/translations/en.json
@@ -12,11 +12,38 @@
           "db_sensor": "Database size sensor (optional)"
         },
         "data_description": {
-          "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
-          "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
+          "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
+          "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
           "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size')."
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "fallback_missing": {
+      "message": "PSI is unavailable, and CPU and RAM fallback sensors are not configured."
+    }
+  },
+  "issues": {
+    "fallback_missing": {
+      "title": "PSI is unavailable and fallback sensors are missing",
+      "description": "HAGHS cannot start because Linux PSI data is unavailable and CPU/RAM fallback sensors are not configured. Provide both sensors to recover without restarting Home Assistant.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Configure CPU and RAM fallback sensors",
+            "description": "Select both fallback sensors and submit to update this integration entry.",
+            "data": {
+              "cpu_sensor": "CPU usage sensor",
+              "ram_sensor": "RAM usage sensor"
+            },
+            "data_description": {
+              "cpu_sensor": "Select the sensor that reports CPU usage in percent.",
+              "ram_sensor": "Select the sensor that reports memory usage in percent."
+            }
+          }
         }
       }
     }
@@ -35,8 +62,8 @@
           "update_interval": "Update interval"
         },
         "data_description": {
-          "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
-          "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
+          "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
+          "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
           "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size').",

--- a/custom_components/haghs/translations/en.json
+++ b/custom_components/haghs/translations/en.json
@@ -8,7 +8,7 @@
           "cpu_sensor": "CPU usage sensor",
           "ram_sensor": "RAM usage sensor",
           "storage_type": "Storage type",
-          "ignore_label": "Ignore label",
+          "ignore_labels": "Ignore labels",
           "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)"
         },
@@ -16,7 +16,7 @@
           "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
           "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
-          "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
+          "ignore_labels": "Select one or more labels from your Home Assistant labels. Entities and devices carrying any of these labels are excluded from zombie detection and update penalties. Toggle exclusions dynamically from an automation by calling Home Assistant's native 'label.assign' and 'label.remove' service actions (e.g. switch a 'vacation' label on while you are away). Create the labels first under Settings → Labels if they do not exist yet.",
           "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size')."
         }
@@ -58,7 +58,7 @@
           "cpu_sensor": "CPU usage sensor",
           "ram_sensor": "RAM usage sensor",
           "storage_type": "Storage type",
-          "ignore_label": "Ignore label",
+          "ignore_labels": "Ignore labels",
           "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)",
           "update_interval": "Update interval"
@@ -67,7 +67,7 @@
           "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
           "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
-          "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
+          "ignore_labels": "Select one or more labels from your Home Assistant labels. Entities and devices carrying any of these labels are excluded from zombie detection and update penalties. Toggle exclusions dynamically from an automation by calling Home Assistant's native 'label.assign' and 'label.remove' service actions (e.g. switch a 'vacation' label on while you are away). Create the labels first under Settings → Labels if they do not exist yet.",
           "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size').",
           "update_interval": "How often HAGHS recalculates the health score, in seconds. Lower values mean faster updates but slightly more CPU usage. Default: 60 seconds."

--- a/custom_components/haghs/translations/en.json
+++ b/custom_components/haghs/translations/en.json
@@ -61,7 +61,9 @@
           "ignore_labels": "Ignore labels",
           "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)",
-          "update_interval": "Update interval"
+          "update_interval": "Update interval",
+          "zombie_grace_minutes": "Zombie grace period (minutes)",
+          "battery_grace_minutes": "Battery-class grace period (minutes)"
         },
         "data_description": {
           "cpu_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports CPU usage in percent (e.g. 'Processor Use').",
@@ -70,7 +72,9 @@
           "ignore_labels": "Select one or more labels from your Home Assistant labels. Entities and devices carrying any of these labels are excluded from zombie detection and update penalties. Toggle exclusions dynamically from an automation by calling Home Assistant's native 'label.assign' and 'label.remove' service actions (e.g. switch a 'vacation' label on while you are away). Create the labels first under Settings → Labels if they do not exist yet.",
           "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size').",
-          "update_interval": "How often HAGHS recalculates the health score, in seconds. Lower values mean faster updates but slightly more CPU usage. Default: 60 seconds."
+          "update_interval": "How often HAGHS recalculates the health score, in seconds. Lower values mean faster updates but slightly more CPU usage. Default: 60 seconds.",
+          "zombie_grace_minutes": "How long an entity must stay in 'unavailable' or 'unknown' before HAGHS counts it as a zombie. Allowed range: 1 to 240 minutes. Lower values make detection more aggressive (more false positives from briefly-offline devices). Higher values mask short outages but let real failures linger. Default: 15 minutes.",
+          "battery_grace_minutes": "Extended grace period specifically for entities with 'device_class: battery'. Zigbee and Homematic radios routinely take longer than the regular window to re-poll battery devices, so flagging them as zombies after only 15 minutes produces false positives. Allowed range: 1 to 240 minutes. If you set this lower than the regular grace, it effectively disables the extension. Default: 60 minutes."
         }
       }
     }

--- a/custom_components/haghs/translations/en.json
+++ b/custom_components/haghs/translations/en.json
@@ -29,12 +29,11 @@
   "issues": {
     "fallback_missing": {
       "title": "PSI is unavailable and fallback sensors are missing",
-      "description": "HAGHS cannot start because Linux PSI data is unavailable and CPU/RAM fallback sensors are not configured. Provide both sensors to recover without restarting Home Assistant.",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Configure CPU and RAM fallback sensors",
-            "description": "Select both fallback sensors and submit to update this integration entry.",
+            "description": "HAGHS cannot start because Linux PSI data is unavailable and CPU/RAM fallback sensors are not configured. Select both sensors below and submit to recover without restarting Home Assistant.",
             "data": {
               "cpu_sensor": "CPU usage sensor",
               "ram_sensor": "RAM usage sensor"

--- a/custom_components/haghs/translations/en.json
+++ b/custom_components/haghs/translations/en.json
@@ -9,6 +9,7 @@
           "ram_sensor": "RAM usage sensor",
           "storage_type": "Storage type",
           "ignore_label": "Ignore label",
+          "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)"
         },
         "data_description": {
@@ -16,6 +17,7 @@
           "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
           "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
+          "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size')."
         }
       }
@@ -57,6 +59,7 @@
           "ram_sensor": "RAM usage sensor",
           "storage_type": "Storage type",
           "ignore_label": "Ignore label",
+          "ignore_patterns": "Ignore entity-id patterns",
           "db_sensor": "Database size sensor (optional)",
           "update_interval": "Update interval"
         },
@@ -65,6 +68,7 @@
           "ram_sensor": "Smart fallback only. HAGHS uses high-precision Linux PSI (Pressure Stall Information) values from your host system by default to calculate the score. This manual sensor is only used if your system does not provide PSI data (e.g. Windows, older Docker setups, or non-Linux hosts). If PSI becomes unavailable and no CPU/RAM fallback sensors are configured, setup will be rejected. Select the sensor that reports memory usage in percent (e.g. 'Memory Use Percent').",
           "storage_type": "Choose the type of storage your HA instance runs on. SD card is the safe default for Raspberry Pi setups. SSD uses percentage-based thresholds instead of absolute free space.",
           "ignore_label": "Select a label from your Home Assistant labels. Entities and devices with this label are excluded from zombie detection and update penalties. Create the label first under Settings → Labels if it does not exist yet.",
+          "ignore_patterns": "Optional list of glob patterns matched against the entity_id (one per line). Entities whose id matches any pattern are excluded from zombie detection and update penalties. Use this for entities without a unique ID, which cannot carry a label (e.g. 'sensor.docker_*'). Wildcards * and ? are supported.",
           "db_sensor": "Only needed for external databases (MariaDB, PostgreSQL). Leave empty to use the built-in SQLite auto-detection. The sensor must report database size in MB (e.g. 'sensor.mariadb_size').",
           "update_interval": "How often HAGHS recalculates the health score, in seconds. Lower values mean faster updates but slightly more CPU usage. Default: 60 seconds."
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = [
+    "-q",
+    "--strict-markers",
+    "--strict-config",
+]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "F",
+    "W",
+    "I",
+    "B",
+    "UP",
+    "ASYNC",
+    "PT",
+    "RUF",
+]
+ignore = [
+    "E501",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B011", "PT011"]
+
+[tool.coverage.run]
+source = ["custom_components/haghs"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,5 @@
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+pytest-cov>=5.0.0
+pytest-homeassistant-custom-component>=0.13.190
+ruff>=0.6.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,42 @@
+# HAGHS Test Suite
+
+Bootstrapped per issue [#54](https://github.com/d-n91/home-assistant-global-health-score/issues/54).
+
+## Running tests locally
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements_test.txt
+pytest
+```
+
+`pytest-asyncio` is configured in `auto` mode via `pyproject.toml`, so async
+tests do not need a per-test marker.
+
+## Coverage
+
+```bash
+pytest --cov=custom_components.haghs --cov-report=term-missing
+```
+
+## Linting
+
+```bash
+ruff check .
+ruff format --check .
+```
+
+## Layout
+
+- `tests/conftest.py` — global fixtures (auto-enables `custom_integrations`).
+- `tests/test_*.py` — one file per concern (migration, scoring pillars, …).
+
+## Roadmap
+
+Per issue #54 the suite grows in three phases:
+
+1. Infrastructure (this commit).
+2. Migration tests covering every branch of `_migrate_ignore_label_value` and
+   `async_migrate_entry`.
+3. Scoring-pillar pilot test (suggested: `p_power` / power supply detection).

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the HAGHS integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the HAGHS test suite."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,12 @@
 """Common fixtures for the HAGHS test suite."""
 from __future__ import annotations
 
-from collections.abc import Generator
-
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(
     enable_custom_integrations: None,
-) -> Generator[None, None, None]:
+) -> None:
     """Enable loading of the HAGHS custom integration in every test."""
-    yield
+    return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Common fixtures for the HAGHS test suite."""
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(
+    enable_custom_integrations: None,
+) -> Generator[None, None, None]:
+    """Enable loading of the HAGHS custom integration in every test."""
+    yield

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,0 +1,102 @@
+"""Tests for the application-pillar hard cap (#7)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haghs.const import DATA_BOOT_TIME, DOMAIN
+from custom_components.haghs.coordinator import (
+    HaghsDataUpdateCoordinator,
+    _RecorderInfo,
+)
+
+
+def _make_zombie(hass: HomeAssistant, entity_id: str, age_minutes: int = 30) -> None:
+    """Mark a state as STATE_UNAVAILABLE with last_changed in the past."""
+    hass.states.async_set(entity_id, STATE_UNAVAILABLE)
+    state = hass.states.get(entity_id)
+    state.last_changed = dt_util.utcnow() - timedelta(minutes=age_minutes)
+
+
+def _coordinator_with_recorder_bonus(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    *,
+    boot_age_minutes: int = 60,
+    bonus_full: bool = True,
+) -> HaghsDataUpdateCoordinator:
+    """Create a coordinator with a populated recorder_info granting +10 bonus."""
+    hass.data.setdefault(DOMAIN, {})[DATA_BOOT_TIME] = dt_util.utcnow() - timedelta(
+        minutes=boot_age_minutes
+    )
+    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    coordinator.recorder_info = _RecorderInfo(
+        keep_days=10 if bonus_full else None,
+        entity_filter_active=bonus_full,
+        available=True,
+    )
+    return coordinator
+
+
+async def test_hard_cap_prevents_score_100_when_zombies_present(
+    hass: HomeAssistant,
+) -> None:
+    """A single zombie among many healthy sensors must not yield app_score 100.
+
+    Reproduces #7: a small ratio-based p_zombie (e.g. 7) could previously be
+    fully offset by the +10 config bonus, hiding the zombie behind a perfect
+    score.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(99):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+    _make_zombie(hass, "sensor.lone_zombie", age_minutes=60)
+
+    coordinator = _coordinator_with_recorder_bonus(hass, entry)
+    result = await coordinator._async_calc_application()
+
+    assert result.zombie_count == 1
+    assert result.config_bonus == 10
+    assert result.app_score <= 99
+
+
+async def test_app_score_100_possible_without_zombies(hass: HomeAssistant) -> None:
+    """A healthy instance with full bonus still reaches the perfect score."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(10):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+
+    coordinator = _coordinator_with_recorder_bonus(hass, entry)
+    result = await coordinator._async_calc_application()
+
+    assert result.zombie_count == 0
+    assert result.config_bonus == 10
+    assert result.app_score == 100
+
+
+async def test_hard_cap_does_not_inflate_lower_scores(hass: HomeAssistant) -> None:
+    """The cap only applies when the natural score would have reached 100."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    # Many sensors to keep p_zombie small (1 / 50 -> ratio 2 % -> ceil(14) = 14)
+    for i in range(49):
+        hass.states.async_set(f"sensor.ok_{i}", "100")
+    _make_zombie(hass, "sensor.bad", age_minutes=60)
+    # Add a stale-backup penalty (+30) so the natural score is well under 99.
+    hass.states.async_set("binary_sensor.backups_stale", "on")
+
+    coordinator = _coordinator_with_recorder_bonus(hass, entry)
+    result = await coordinator._async_calc_application()
+
+    assert result.zombie_count == 1
+    assert result.app_score < 99

--- a/tests/test_hardware_power.py
+++ b/tests/test_hardware_power.py
@@ -1,0 +1,131 @@
+"""Pilot golden tests for the power-supply pillar (#54 phase 3).
+
+Picked as the simplest pillar in HAGHS: a single binary state (`on` or
+`off`) translates into a flat 20-point penalty applied after the
+hardware-pillar averaging. These tests establish the input/output
+pattern that future per-pillar suites should follow.
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haghs.const import DOMAIN, REC_POWER_UNSTABLE
+from custom_components.haghs.coordinator import (
+    HaghsDataUpdateCoordinator,
+    _ApplicationResult,
+)
+
+POWER_ENTITY = "binary_sensor.rpi_power_status"
+
+
+def _coordinator(hass: HomeAssistant) -> HaghsDataUpdateCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    return HaghsDataUpdateCoordinator(hass, entry)
+
+
+# ============================================================================
+# Penalty calculation (_async_calc_hardware -> _HardwareResult.p_power)
+# ============================================================================
+
+
+async def test_p_power_zero_when_sensor_absent(hass: HomeAssistant) -> None:
+    """No rpi_power_status entity at all yields p_power = 0.
+
+    Most non-RPi hardware never creates this entity, so the check must
+    be invisible to those users.
+    """
+    coordinator = _coordinator(hass)
+    result = await coordinator._async_calc_hardware()
+    assert result.p_power == 0
+
+
+async def test_p_power_twenty_when_problem_reported(hass: HomeAssistant) -> None:
+    """rpi_power_status 'on' indicates under-voltage; p_power = 20."""
+    hass.states.async_set(POWER_ENTITY, "on")
+    coordinator = _coordinator(hass)
+    result = await coordinator._async_calc_hardware()
+    assert result.p_power == 20
+
+
+async def test_p_power_zero_when_status_ok(hass: HomeAssistant) -> None:
+    """rpi_power_status 'off' indicates normal supply; p_power = 0."""
+    hass.states.async_set(POWER_ENTITY, "off")
+    coordinator = _coordinator(hass)
+    result = await coordinator._async_calc_hardware()
+    assert result.p_power == 0
+
+
+async def test_p_power_zero_when_sensor_unavailable(hass: HomeAssistant) -> None:
+    """rpi_power_status 'unavailable' is treated as no penalty."""
+    hass.states.async_set(POWER_ENTITY, "unavailable")
+    coordinator = _coordinator(hass)
+    result = await coordinator._async_calc_hardware()
+    assert result.p_power == 0
+
+
+async def test_p_power_zero_when_sensor_unknown(hass: HomeAssistant) -> None:
+    """rpi_power_status 'unknown' is treated as no penalty."""
+    hass.states.async_set(POWER_ENTITY, "unknown")
+    coordinator = _coordinator(hass)
+    result = await coordinator._async_calc_hardware()
+    assert result.p_power == 0
+
+
+# ============================================================================
+# Hardware-score integration
+# ============================================================================
+
+
+async def test_hardware_score_drops_when_power_unstable(hass: HomeAssistant) -> None:
+    """Hardware score loses 20 points when the power penalty is active.
+
+    Invariant: hardware_score = clamp(average - p_power, 0, 100). With
+    p_power = 20 the score is therefore at most 80, regardless of which
+    other pillars contribute.
+    """
+    hass.states.async_set(POWER_ENTITY, "on")
+    coordinator = _coordinator(hass)
+    result = await coordinator._async_calc_hardware()
+    assert result.p_power == 20
+    assert result.hardware_score <= 80
+
+
+# ============================================================================
+# Recommendation surface (_build_recommendations + _build_rec_flags)
+# ============================================================================
+
+
+async def test_advice_contains_power_message_when_unstable(
+    hass: HomeAssistant,
+) -> None:
+    """REC_POWER_UNSTABLE appears in the advice list when p_power > 0."""
+    hass.states.async_set(POWER_ENTITY, "on")
+    coordinator = _coordinator(hass)
+    hw = await coordinator._async_calc_hardware()
+    advice = coordinator._build_recommendations(hw, _ApplicationResult())
+    assert REC_POWER_UNSTABLE in advice
+
+
+async def test_rec_power_unstable_flag_true_when_unstable(
+    hass: HomeAssistant,
+) -> None:
+    """The rec_power_unstable boolean mirrors the recommendation."""
+    hass.states.async_set(POWER_ENTITY, "on")
+    coordinator = _coordinator(hass)
+    hw = await coordinator._async_calc_hardware()
+    flags = coordinator._build_rec_flags(hw, _ApplicationResult())
+    assert flags["rec_power_unstable"] is True
+
+
+async def test_rec_power_unstable_flag_false_when_status_ok(
+    hass: HomeAssistant,
+) -> None:
+    """The rec_power_unstable boolean is False when no penalty is active."""
+    hass.states.async_set(POWER_ENTITY, "off")
+    coordinator = _coordinator(hass)
+    hw = await coordinator._async_calc_hardware()
+    flags = coordinator._build_rec_flags(hw, _ApplicationResult())
+    assert flags["rec_power_unstable"] is False

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -10,9 +10,15 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.haghs import (
     _migrate_ignore_label_value,
+    _migrate_label_to_labels,
     async_migrate_entry,
 )
-from custom_components.haghs.const import _CONFIG_VERSION, CONF_IGNORE_LABEL, DOMAIN
+from custom_components.haghs.const import (
+    _CONFIG_VERSION,
+    CONF_IGNORE_LABEL,
+    CONF_IGNORE_LABELS,
+    DOMAIN,
+)
 
 
 def _mock_registry(
@@ -143,7 +149,11 @@ def test_create_raises_second_lookup_misses_pops_value(caplog) -> None:
 async def test_migrate_from_v2_0_bumps_version_and_rewrites_label(
     hass: HomeAssistant,
 ) -> None:
-    """v2.0 entry is migrated to the current version and label is converted."""
+    """v2.0 entry is migrated to the current version and label is converted.
+
+    The label first gets rewritten to its label_id (3.2 step) and then
+    promoted into the new CONF_IGNORE_LABELS list (3.4 step).
+    """
     label_registry = lr.async_get(hass)
     label = label_registry.async_create("Legacy Label")
 
@@ -159,7 +169,8 @@ async def test_migrate_from_v2_0_bumps_version_and_rewrites_label(
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == _CONFIG_VERSION.major
     assert entry.minor_version == _CONFIG_VERSION.minor
-    assert entry.data[CONF_IGNORE_LABEL] == label.label_id
+    assert CONF_IGNORE_LABEL not in entry.data
+    assert entry.data[CONF_IGNORE_LABELS] == [label.label_id]
 
 
 async def test_migrate_from_v3_1_only_touches_label_field(
@@ -185,15 +196,16 @@ async def test_migrate_from_v3_1_only_touches_label_field(
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == _CONFIG_VERSION.major
     assert entry.minor_version == _CONFIG_VERSION.minor
-    assert entry.data[CONF_IGNORE_LABEL] == label.label_id
+    assert CONF_IGNORE_LABEL not in entry.data
+    assert entry.data[CONF_IGNORE_LABELS] == [label.label_id]
     assert entry.data["cpu_sensor"] == "sensor.cpu_use"
     assert entry.data["storage_type"] == "ssd"
 
 
-async def test_migrate_from_v3_2_bumps_to_current_without_label_work(
+async def test_migrate_from_v3_2_promotes_label_to_labels_list(
     hass: HomeAssistant,
 ) -> None:
-    """v3.2 entry already holds a label_id and only needs the version bump."""
+    """v3.2 entry skips the label-id rewrite and is promoted to the new list."""
     label_registry = lr.async_get(hass)
     label = label_registry.async_create("Ignore Me")
 
@@ -209,10 +221,32 @@ async def test_migrate_from_v3_2_bumps_to_current_without_label_work(
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == _CONFIG_VERSION.major
     assert entry.minor_version == _CONFIG_VERSION.minor
-    assert entry.data[CONF_IGNORE_LABEL] == label.label_id
+    assert CONF_IGNORE_LABEL not in entry.data
+    assert entry.data[CONF_IGNORE_LABELS] == [label.label_id]
 
     # B2 regression: no second label was created whose name equals the ID.
     assert label_registry.async_get_label_by_name(label.label_id) is None
+
+
+async def test_migrate_from_v3_3_promotes_label_only(hass: HomeAssistant) -> None:
+    """v3.3 entry uses only the 3.4 label-list promotion, nothing else."""
+    label_registry = lr.async_get(hass)
+    label = label_registry.async_create("Existing")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        minor_version=3,
+        data={CONF_IGNORE_LABEL: label.label_id},
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == _CONFIG_VERSION.major
+    assert entry.minor_version == _CONFIG_VERSION.minor
+    assert CONF_IGNORE_LABEL not in entry.data
+    assert entry.data[CONF_IGNORE_LABELS] == [label.label_id]
 
 
 async def test_migrate_at_current_version_is_noop(hass: HomeAssistant) -> None:
@@ -224,7 +258,7 @@ async def test_migrate_at_current_version_is_noop(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         version=_CONFIG_VERSION.major,
         minor_version=_CONFIG_VERSION.minor,
-        data={CONF_IGNORE_LABEL: label.label_id},
+        data={CONF_IGNORE_LABELS: [label.label_id]},
         options={},
     )
     entry.add_to_hass(hass)
@@ -232,7 +266,8 @@ async def test_migrate_at_current_version_is_noop(hass: HomeAssistant) -> None:
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == _CONFIG_VERSION.major
     assert entry.minor_version == _CONFIG_VERSION.minor
-    assert entry.data[CONF_IGNORE_LABEL] == label.label_id
+    assert entry.data[CONF_IGNORE_LABELS] == [label.label_id]
+    assert CONF_IGNORE_LABEL not in entry.data
 
 
 async def test_migrate_handles_data_and_options_independently(
@@ -253,5 +288,46 @@ async def test_migrate_handles_data_and_options_independently(
     entry.add_to_hass(hass)
 
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.data[CONF_IGNORE_LABEL] == data_label.label_id
-    assert entry.options[CONF_IGNORE_LABEL] == options_label.label_id
+    assert CONF_IGNORE_LABEL not in entry.data
+    assert CONF_IGNORE_LABEL not in entry.options
+    assert entry.data[CONF_IGNORE_LABELS] == [data_label.label_id]
+    assert entry.options[CONF_IGNORE_LABELS] == [options_label.label_id]
+
+
+# ============================================================================
+# _migrate_label_to_labels — direct unit tests
+# ============================================================================
+
+
+def test_label_to_labels_no_legacy_key() -> None:
+    """Absent CONF_IGNORE_LABEL leaves the dict untouched."""
+    config: dict = {}
+    assert _migrate_label_to_labels(config) is False
+    assert config == {}
+
+
+def test_label_to_labels_empty_value_drops_key() -> None:
+    """Empty / falsy legacy value still has the key removed for cleanliness."""
+    config = {CONF_IGNORE_LABEL: ""}
+    assert _migrate_label_to_labels(config) is False
+    assert CONF_IGNORE_LABEL not in config
+    assert CONF_IGNORE_LABELS not in config
+
+
+def test_label_to_labels_promotes_single_value() -> None:
+    """A single legacy label_id becomes a one-element list."""
+    config = {CONF_IGNORE_LABEL: "haghs_ignore"}
+    assert _migrate_label_to_labels(config) is True
+    assert CONF_IGNORE_LABEL not in config
+    assert config[CONF_IGNORE_LABELS] == ["haghs_ignore"]
+
+
+def test_label_to_labels_idempotent_when_coexisting() -> None:
+    """If both keys somehow coexist, the legacy value merges without duplicating."""
+    config = {
+        CONF_IGNORE_LABEL: "haghs_ignore",
+        CONF_IGNORE_LABELS: ["haghs_ignore", "vacation"],
+    }
+    assert _migrate_label_to_labels(config) is True
+    assert CONF_IGNORE_LABEL not in config
+    assert config[CONF_IGNORE_LABELS] == ["haghs_ignore", "vacation"]

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -12,7 +12,7 @@ from custom_components.haghs import (
     _migrate_ignore_label_value,
     async_migrate_entry,
 )
-from custom_components.haghs.const import CONF_IGNORE_LABEL, DOMAIN
+from custom_components.haghs.const import _CONFIG_VERSION, CONF_IGNORE_LABEL, DOMAIN
 
 
 def _mock_registry(
@@ -143,7 +143,7 @@ def test_create_raises_second_lookup_misses_pops_value(caplog) -> None:
 async def test_migrate_from_v2_0_bumps_version_and_rewrites_label(
     hass: HomeAssistant,
 ) -> None:
-    """v2.0 entry is migrated to (3, 2) and the label is converted to its ID."""
+    """v2.0 entry is migrated to the current version and label is converted."""
     label_registry = lr.async_get(hass)
     label = label_registry.async_create("Legacy Label")
 
@@ -157,15 +157,15 @@ async def test_migrate_from_v2_0_bumps_version_and_rewrites_label(
     entry.add_to_hass(hass)
 
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.version == 3
-    assert entry.minor_version == 2
+    assert entry.version == _CONFIG_VERSION.major
+    assert entry.minor_version == _CONFIG_VERSION.minor
     assert entry.data[CONF_IGNORE_LABEL] == label.label_id
 
 
 async def test_migrate_from_v3_1_only_touches_label_field(
     hass: HomeAssistant,
 ) -> None:
-    """v3.1 entry is bumped to (3, 2); unrelated fields are preserved."""
+    """v3.1 entry is bumped to the current version; other fields are preserved."""
     label_registry = lr.async_get(hass)
     label = label_registry.async_create("Older Label")
 
@@ -183,21 +183,17 @@ async def test_migrate_from_v3_1_only_touches_label_field(
     entry.add_to_hass(hass)
 
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.version == 3
-    assert entry.minor_version == 2
+    assert entry.version == _CONFIG_VERSION.major
+    assert entry.minor_version == _CONFIG_VERSION.minor
     assert entry.data[CONF_IGNORE_LABEL] == label.label_id
     assert entry.data["cpu_sensor"] == "sensor.cpu_use"
     assert entry.data["storage_type"] == "ssd"
 
 
-async def test_migrate_at_current_version_does_not_corrupt_data(
+async def test_migrate_from_v3_2_bumps_to_current_without_label_work(
     hass: HomeAssistant,
 ) -> None:
-    """B2 regression: an already-migrated v3.2 entry is left untouched.
-
-    Without the idempotency guard, the migration would create a duplicate
-    label whose name equals the existing label's ID.
-    """
+    """v3.2 entry already holds a label_id and only needs the version bump."""
     label_registry = lr.async_get(hass)
     label = label_registry.async_create("Ignore Me")
 
@@ -211,12 +207,32 @@ async def test_migrate_at_current_version_does_not_corrupt_data(
     entry.add_to_hass(hass)
 
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.version == 3
-    assert entry.minor_version == 2
+    assert entry.version == _CONFIG_VERSION.major
+    assert entry.minor_version == _CONFIG_VERSION.minor
     assert entry.data[CONF_IGNORE_LABEL] == label.label_id
 
-    # No second label was created whose name equals the existing label's ID.
+    # B2 regression: no second label was created whose name equals the ID.
     assert label_registry.async_get_label_by_name(label.label_id) is None
+
+
+async def test_migrate_at_current_version_is_noop(hass: HomeAssistant) -> None:
+    """An entry already at _CONFIG_VERSION returns early without touching data."""
+    label_registry = lr.async_get(hass)
+    label = label_registry.async_create("Already Done")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=_CONFIG_VERSION.major,
+        minor_version=_CONFIG_VERSION.minor,
+        data={CONF_IGNORE_LABEL: label.label_id},
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == _CONFIG_VERSION.major
+    assert entry.minor_version == _CONFIG_VERSION.minor
+    assert entry.data[CONF_IGNORE_LABEL] == label.label_id
 
 
 async def test_migrate_handles_data_and_options_independently(

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,241 @@
+"""Migration tests for HAGHS config entries (issue #54, phase 2)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import label_registry as lr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haghs import (
+    _migrate_ignore_label_value,
+    async_migrate_entry,
+)
+from custom_components.haghs.const import CONF_IGNORE_LABEL, DOMAIN
+
+
+def _mock_registry(
+    *,
+    label_by_id: object = None,
+    label_by_name_responses: list[object] | None = None,
+    create_side_effect: object = None,
+    create_return: object = None,
+) -> MagicMock:
+    """Build a MagicMock LabelRegistry with controlled responses."""
+    registry = MagicMock(spec=lr.LabelRegistry)
+    registry.async_get_label.return_value = label_by_id
+    if label_by_name_responses is not None:
+        registry.async_get_label_by_name.side_effect = label_by_name_responses
+    else:
+        registry.async_get_label_by_name.return_value = None
+    if create_side_effect is not None:
+        registry.async_create.side_effect = create_side_effect
+    else:
+        registry.async_create.return_value = create_return
+    return registry
+
+
+# ============================================================================
+# _migrate_ignore_label_value — branch coverage with mocked LabelRegistry
+# ============================================================================
+
+
+def test_no_ignore_label_key() -> None:
+    """CONF_IGNORE_LABEL key absent in config dict gives a clean no-op."""
+    registry = _mock_registry()
+    config: dict = {}
+
+    assert _migrate_ignore_label_value(registry, config) is True
+    assert config == {}
+    registry.async_get_label.assert_not_called()
+    registry.async_create.assert_not_called()
+
+
+def test_empty_string_value() -> None:
+    """Empty string is treated as no value."""
+    registry = _mock_registry()
+    config = {CONF_IGNORE_LABEL: ""}
+
+    assert _migrate_ignore_label_value(registry, config) is True
+    assert config == {CONF_IGNORE_LABEL: ""}
+    registry.async_get_label.assert_not_called()
+
+
+def test_none_value() -> None:
+    """None is treated as no value."""
+    registry = _mock_registry()
+    config = {CONF_IGNORE_LABEL: None}
+
+    assert _migrate_ignore_label_value(registry, config) is True
+    assert config == {CONF_IGNORE_LABEL: None}
+    registry.async_get_label.assert_not_called()
+
+
+def test_already_label_id_is_idempotent() -> None:
+    """B2 guard: a value that is already a known label ID skips conversion."""
+    existing = MagicMock(label_id="haghs_ignore")
+    registry = _mock_registry(label_by_id=existing)
+    config = {CONF_IGNORE_LABEL: "haghs_ignore"}
+
+    assert _migrate_ignore_label_value(registry, config) is True
+    assert config == {CONF_IGNORE_LABEL: "haghs_ignore"}
+    registry.async_get_label_by_name.assert_not_called()
+    registry.async_create.assert_not_called()
+
+
+def test_label_name_existing_resolved_to_id() -> None:
+    """A known label name is rewritten to its label_id."""
+    found = MagicMock(label_id="my_ignore_label")
+    registry = _mock_registry(label_by_name_responses=[found])
+    config = {CONF_IGNORE_LABEL: "My Ignore Label"}
+
+    assert _migrate_ignore_label_value(registry, config) is True
+    assert config[CONF_IGNORE_LABEL] == "my_ignore_label"
+    registry.async_create.assert_not_called()
+
+
+def test_label_name_unknown_creates_label() -> None:
+    """Unknown label name leads to async_create being called once."""
+    created = MagicMock(label_id="new_label")
+    registry = _mock_registry(create_return=created)
+    config = {CONF_IGNORE_LABEL: "New Label"}
+
+    assert _migrate_ignore_label_value(registry, config) is True
+    assert config[CONF_IGNORE_LABEL] == "new_label"
+    registry.async_create.assert_called_once_with("New Label")
+
+
+def test_create_raises_second_lookup_finds_label() -> None:
+    """ValueError on async_create + second name lookup finds the racing label."""
+    found_after_race = MagicMock(label_id="race_label")
+    registry = _mock_registry(
+        label_by_name_responses=[None, found_after_race],
+        create_side_effect=ValueError("already exists"),
+    )
+    config = {CONF_IGNORE_LABEL: "Race Label"}
+
+    assert _migrate_ignore_label_value(registry, config) is True
+    assert config[CONF_IGNORE_LABEL] == "race_label"
+    assert registry.async_get_label_by_name.call_count == 2
+
+
+def test_create_raises_second_lookup_misses_pops_value(caplog) -> None:
+    """ValueError + second lookup also missing pops the key and warns."""
+    registry = _mock_registry(
+        label_by_name_responses=[None, None],
+        create_side_effect=ValueError("collision"),
+    )
+    config = {CONF_IGNORE_LABEL: "Lost Label"}
+
+    with caplog.at_level("WARNING"):
+        assert _migrate_ignore_label_value(registry, config) is True
+
+    assert CONF_IGNORE_LABEL not in config
+    assert "Could not migrate ignore label" in caplog.text
+
+
+# ============================================================================
+# async_migrate_entry — integration with real hass + MockConfigEntry
+# ============================================================================
+
+
+async def test_migrate_from_v2_0_bumps_version_and_rewrites_label(
+    hass: HomeAssistant,
+) -> None:
+    """v2.0 entry is migrated to (3, 2) and the label is converted to its ID."""
+    label_registry = lr.async_get(hass)
+    label = label_registry.async_create("Legacy Label")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        minor_version=0,
+        data={CONF_IGNORE_LABEL: "Legacy Label"},
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 3
+    assert entry.minor_version == 2
+    assert entry.data[CONF_IGNORE_LABEL] == label.label_id
+
+
+async def test_migrate_from_v3_1_only_touches_label_field(
+    hass: HomeAssistant,
+) -> None:
+    """v3.1 entry is bumped to (3, 2); unrelated fields are preserved."""
+    label_registry = lr.async_get(hass)
+    label = label_registry.async_create("Older Label")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        minor_version=1,
+        data={
+            CONF_IGNORE_LABEL: "Older Label",
+            "cpu_sensor": "sensor.cpu_use",
+            "storage_type": "ssd",
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 3
+    assert entry.minor_version == 2
+    assert entry.data[CONF_IGNORE_LABEL] == label.label_id
+    assert entry.data["cpu_sensor"] == "sensor.cpu_use"
+    assert entry.data["storage_type"] == "ssd"
+
+
+async def test_migrate_at_current_version_does_not_corrupt_data(
+    hass: HomeAssistant,
+) -> None:
+    """B2 regression: an already-migrated v3.2 entry is left untouched.
+
+    Without the idempotency guard, the migration would create a duplicate
+    label whose name equals the existing label's ID.
+    """
+    label_registry = lr.async_get(hass)
+    label = label_registry.async_create("Ignore Me")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        minor_version=2,
+        data={CONF_IGNORE_LABEL: label.label_id},
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 3
+    assert entry.minor_version == 2
+    assert entry.data[CONF_IGNORE_LABEL] == label.label_id
+
+    # No second label was created whose name equals the existing label's ID.
+    assert label_registry.async_get_label_by_name(label.label_id) is None
+
+
+async def test_migrate_handles_data_and_options_independently(
+    hass: HomeAssistant,
+) -> None:
+    """Both entry.data and entry.options are migrated in a single run."""
+    label_registry = lr.async_get(hass)
+    data_label = label_registry.async_create("Data Label")
+    options_label = label_registry.async_create("Options Label")
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=3,
+        minor_version=0,
+        data={CONF_IGNORE_LABEL: "Data Label"},
+        options={CONF_IGNORE_LABEL: "Options Label"},
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.data[CONF_IGNORE_LABEL] == data_label.label_id
+    assert entry.options[CONF_IGNORE_LABEL] == options_label.label_id

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -62,14 +62,14 @@ async def test_clearing_db_sensor_persists(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_STORAGE_TYPE: "sd",
+            CONF_STORAGE_TYPE: "sd-card",
             CONF_DB_SENSOR: "sensor.wrongly_picked_at_install",
         },
         options={},
     )
     entry.add_to_hass(hass)
 
-    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd"})
+    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd-card"})
 
     assert entry.options[CONF_DB_SENSOR] is None
     assert _merged(entry)[CONF_DB_SENSOR] is None
@@ -80,14 +80,14 @@ async def test_clearing_ignore_labels_persists(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_STORAGE_TYPE: "sd",
+            CONF_STORAGE_TYPE: "sd-card",
             CONF_IGNORE_LABELS: ["legacy_label"],
         },
         options={},
     )
     entry.add_to_hass(hass)
 
-    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd"})
+    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd-card"})
 
     assert entry.options[CONF_IGNORE_LABELS] == []
     assert _merged(entry)[CONF_IGNORE_LABELS] == []
@@ -98,14 +98,14 @@ async def test_clearing_ignore_patterns_persists(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_STORAGE_TYPE: "sd",
+            CONF_STORAGE_TYPE: "sd-card",
             CONF_IGNORE_PATTERNS: ["sensor.docker_*"],
         },
         options={},
     )
     entry.add_to_hass(hass)
 
-    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd"})
+    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd-card"})
 
     assert entry.options[CONF_IGNORE_PATTERNS] == []
     assert _merged(entry)[CONF_IGNORE_PATTERNS] == []
@@ -116,7 +116,7 @@ async def test_clearing_cpu_ram_persists_when_psi_available(hass: HomeAssistant)
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_STORAGE_TYPE: "sd",
+            CONF_STORAGE_TYPE: "sd-card",
             CONF_CPU_SENSOR: "sensor.old_cpu",
             CONF_RAM_SENSOR: "sensor.old_ram",
         },
@@ -124,7 +124,7 @@ async def test_clearing_cpu_ram_persists_when_psi_available(hass: HomeAssistant)
     )
     entry.add_to_hass(hass)
 
-    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd"}, psi=_PSI_AVAILABLE)
+    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd-card"}, psi=_PSI_AVAILABLE)
 
     assert entry.options[CONF_CPU_SENSOR] is None
     assert entry.options[CONF_RAM_SENSOR] is None
@@ -138,7 +138,7 @@ async def test_existing_value_kept_when_field_submitted(hass: HomeAssistant) -> 
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_STORAGE_TYPE: "sd",
+            CONF_STORAGE_TYPE: "sd-card",
             CONF_DB_SENSOR: "sensor.old_db",
         },
         options={},
@@ -148,7 +148,7 @@ async def test_existing_value_kept_when_field_submitted(hass: HomeAssistant) -> 
     await _run_options_flow(
         hass,
         entry,
-        {CONF_STORAGE_TYPE: "sd", CONF_DB_SENSOR: "sensor.new_db"},
+        {CONF_STORAGE_TYPE: "sd-card", CONF_DB_SENSOR: "sensor.new_db"},
     )
 
     assert entry.options[CONF_DB_SENSOR] == "sensor.new_db"

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,155 @@
+"""Options flow persistence tests.
+
+Regression coverage for the community-reported bug where clearing an
+optional field (db_sensor, cpu/ram fallback, ignore labels/patterns)
+silently reverted to the original value after every HA restart because
+the missing key in ``user_input`` never reached ``entry.options`` and
+the ``{**data, **options}`` merge in the coordinator resurrected the
+value from ``entry.data``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haghs.const import (
+    CONF_CPU_SENSOR,
+    CONF_DB_SENSOR,
+    CONF_IGNORE_LABELS,
+    CONF_IGNORE_PATTERNS,
+    CONF_RAM_SENSOR,
+    CONF_STORAGE_TYPE,
+    DOMAIN,
+)
+from custom_components.haghs.coordinator import _PsiData
+
+_PSI_AVAILABLE = _PsiData(cpu=0.5, memory=0.5, io=0.5)
+_PSI_UNAVAILABLE = _PsiData()
+
+
+def _merged(entry: MockConfigEntry) -> dict:
+    """Reproduce the coordinator-side {**data, **options} merge."""
+    return {**entry.data, **entry.options}
+
+
+async def _run_options_flow(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    user_input: dict,
+    *,
+    psi: _PsiData = _PSI_AVAILABLE,
+) -> None:
+    """Open the options flow and submit ``user_input``."""
+    with patch(
+        "custom_components.haghs.coordinator.HaghsDataUpdateCoordinator._read_psi_sync",
+        return_value=psi,
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] == FlowResultType.FORM
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input=user_input
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+
+
+async def test_clearing_db_sensor_persists(hass: HomeAssistant) -> None:
+    """A db_sensor cleared in the options dialog must not resurrect after restart."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STORAGE_TYPE: "sd",
+            CONF_DB_SENSOR: "sensor.wrongly_picked_at_install",
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd"})
+
+    assert entry.options[CONF_DB_SENSOR] is None
+    assert _merged(entry)[CONF_DB_SENSOR] is None
+
+
+async def test_clearing_ignore_labels_persists(hass: HomeAssistant) -> None:
+    """Removing every ignore label must survive a restart-equivalent merge."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STORAGE_TYPE: "sd",
+            CONF_IGNORE_LABELS: ["legacy_label"],
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd"})
+
+    assert entry.options[CONF_IGNORE_LABELS] == []
+    assert _merged(entry)[CONF_IGNORE_LABELS] == []
+
+
+async def test_clearing_ignore_patterns_persists(hass: HomeAssistant) -> None:
+    """Removing every ignore pattern must survive a restart-equivalent merge."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STORAGE_TYPE: "sd",
+            CONF_IGNORE_PATTERNS: ["sensor.docker_*"],
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd"})
+
+    assert entry.options[CONF_IGNORE_PATTERNS] == []
+    assert _merged(entry)[CONF_IGNORE_PATTERNS] == []
+
+
+async def test_clearing_cpu_ram_persists_when_psi_available(hass: HomeAssistant) -> None:
+    """Fallback sensors must be clearable when PSI is available."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STORAGE_TYPE: "sd",
+            CONF_CPU_SENSOR: "sensor.old_cpu",
+            CONF_RAM_SENSOR: "sensor.old_ram",
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    await _run_options_flow(hass, entry, {CONF_STORAGE_TYPE: "sd"}, psi=_PSI_AVAILABLE)
+
+    assert entry.options[CONF_CPU_SENSOR] is None
+    assert entry.options[CONF_RAM_SENSOR] is None
+    merged = _merged(entry)
+    assert merged[CONF_CPU_SENSOR] is None
+    assert merged[CONF_RAM_SENSOR] is None
+
+
+async def test_existing_value_kept_when_field_submitted(hass: HomeAssistant) -> None:
+    """A non-empty submission overrides the prior value and is not normalized away."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_STORAGE_TYPE: "sd",
+            CONF_DB_SENSOR: "sensor.old_db",
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    await _run_options_flow(
+        hass,
+        entry,
+        {CONF_STORAGE_TYPE: "sd", CONF_DB_SENSOR: "sensor.new_db"},
+    )
+
+    assert entry.options[CONF_DB_SENSOR] == "sensor.new_db"
+    assert _merged(entry)[CONF_DB_SENSOR] == "sensor.new_db"

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.haghs.const import DOMAIN, REC_ALL_CLEAR
+from custom_components.haghs.const import DOMAIN, REC_ALL_CLEAR, REC_FLAG_KEYS
 from custom_components.haghs.coordinator import (
+    _GB,
     HaghsDataUpdateCoordinator,
     _ApplicationResult,
     _HardwareResult,
@@ -113,3 +114,90 @@ async def test_no_advice_when_all_clear(hass: HomeAssistant) -> None:
     assert advice == []
     # Smoke check the all-clear constant is still importable + non-empty.
     assert REC_ALL_CLEAR
+
+
+# ============================================================================
+# Boolean recommendation flags (#11)
+# ============================================================================
+
+
+async def test_all_flags_false_for_empty_result(hass: HomeAssistant) -> None:
+    """A clean hardware/application result yields every rec_* flag as False."""
+    coordinator = _coordinator(hass)
+    flags = coordinator._build_rec_flags(_HardwareResult(), _ApplicationResult())
+
+    assert set(flags.keys()) == set(REC_FLAG_KEYS)
+    assert all(value is False for value in flags.values())
+
+
+async def test_flag_keys_match_const(hass: HomeAssistant) -> None:
+    """REC_FLAG_KEYS in const.py mirrors the keys produced at runtime."""
+    coordinator = _coordinator(hass)
+    flags = coordinator._build_rec_flags(_HardwareResult(), _ApplicationResult())
+
+    assert tuple(flags.keys()) == REC_FLAG_KEYS
+
+
+async def test_hardware_flags_fire_on_penalty(hass: HomeAssistant) -> None:
+    """CPU, RAM, IO and power flags are True exactly when their penalty fires."""
+    coordinator = _coordinator(hass)
+    hw = _HardwareResult(p_cpu=10, p_ram=15, p_io=5, p_power=20)
+    flags = coordinator._build_rec_flags(hw, _ApplicationResult())
+
+    assert flags["rec_cpu_load"] is True
+    assert flags["rec_ram_pressure"] is True
+    assert flags["rec_io_pressure"] is True
+    assert flags["rec_power_unstable"] is True
+
+
+async def test_application_flags_fire_on_penalty(hass: HomeAssistant) -> None:
+    """DB, backup, updates, zombie and core-lag flags reflect their conditions."""
+    coordinator = _coordinator(hass)
+    app = _ApplicationResult(
+        db_mb=2000.0,
+        db_limit_mb=1500.0,
+        p_backup=30,
+        update_count=3,
+        zombie_count=2,
+        p_core_lag=20,
+    )
+    flags = coordinator._build_rec_flags(_HardwareResult(), app)
+
+    assert flags["rec_db_over_limit"] is True
+    assert flags["rec_backup_stale"] is True
+    assert flags["rec_updates_pending"] is True
+    assert flags["rec_zombie"] is True
+    assert flags["rec_core_lag"] is True
+
+
+async def test_disk_low_flag_sd_card(hass: HomeAssistant) -> None:
+    """rec_disk_low fires for SD-card storage with less than 5 GB free."""
+    coordinator = _coordinator(hass)
+    coordinator._storage_type = "sd-card"
+    hw = _HardwareResult(disk_total=64 * _GB, disk_free=3 * _GB)
+
+    flags = coordinator._build_rec_flags(hw, _ApplicationResult())
+
+    assert flags["rec_disk_low"] is True
+
+
+async def test_disk_low_flag_ssd(hass: HomeAssistant) -> None:
+    """rec_disk_low fires for SSD storage with less than 10 % free."""
+    coordinator = _coordinator(hass)
+    coordinator._storage_type = "ssd"
+    hw = _HardwareResult(disk_total=1000 * _GB, disk_free=80 * _GB)
+
+    flags = coordinator._build_rec_flags(hw, _ApplicationResult())
+
+    assert flags["rec_disk_low"] is True
+
+
+async def test_disk_low_flag_clear_when_plenty_of_space(hass: HomeAssistant) -> None:
+    """rec_disk_low stays False when both SD and SSD thresholds are clear."""
+    coordinator = _coordinator(hass)
+    coordinator._storage_type = "ssd"
+    hw = _HardwareResult(disk_total=1000 * _GB, disk_free=500 * _GB)
+
+    flags = coordinator._build_rec_flags(hw, _ApplicationResult())
+
+    assert flags["rec_disk_low"] is False

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,0 +1,115 @@
+"""Tests for the recommendation builder, PSI-aware variants (#8)."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haghs.const import DOMAIN, REC_ALL_CLEAR
+from custom_components.haghs.coordinator import (
+    HaghsDataUpdateCoordinator,
+    _ApplicationResult,
+    _HardwareResult,
+)
+
+
+def _coordinator(hass: HomeAssistant) -> HaghsDataUpdateCoordinator:
+    """Create a bare coordinator suitable for unit-testing helpers."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    return HaghsDataUpdateCoordinator(hass, entry)
+
+
+async def test_cpu_psi_text_when_psi_used(hass: HomeAssistant) -> None:
+    """When CPU value came from PSI, the PSI-flavoured template is used."""
+    coordinator = _coordinator(hass)
+    hw = _HardwareResult(cpu=6.5, p_cpu=10, cpu_used_psi=True)
+    app = _ApplicationResult()
+
+    advice = coordinator._build_recommendations(hw, app)
+
+    assert any("PSI CPU stall time" in line for line in advice)
+    assert any("6.5%" in line for line in advice)
+
+
+async def test_cpu_classic_text_when_psi_unavailable(hass: HomeAssistant) -> None:
+    """When CPU value came from the classic sensor, classic wording is used."""
+    coordinator = _coordinator(hass)
+    hw = _HardwareResult(cpu=38.0, p_cpu=10, cpu_used_psi=False)
+    app = _ApplicationResult()
+
+    advice = coordinator._build_recommendations(hw, app)
+
+    assert any("CPU utilization" in line for line in advice)
+    assert not any("PSI" in line for line in advice)
+
+
+async def test_ram_psi_text_when_psi_used(hass: HomeAssistant) -> None:
+    """RAM PSI variant fires when ram_used_psi is True."""
+    coordinator = _coordinator(hass)
+    hw = _HardwareResult(ram=8.0, p_ram=10, ram_used_psi=True)
+    app = _ApplicationResult()
+
+    advice = coordinator._build_recommendations(hw, app)
+
+    assert any("PSI memory stall time" in line for line in advice)
+
+
+async def test_ram_classic_text_when_psi_unavailable(hass: HomeAssistant) -> None:
+    """RAM classic variant fires when ram_used_psi is False."""
+    coordinator = _coordinator(hass)
+    hw = _HardwareResult(ram=82.0, p_ram=15, ram_used_psi=False)
+    app = _ApplicationResult()
+
+    advice = coordinator._build_recommendations(hw, app)
+
+    assert any("Memory utilization" in line for line in advice)
+
+
+async def test_io_text_unchanged(hass: HomeAssistant) -> None:
+    """IO has no classic fallback, so the existing wording stays as-is."""
+    coordinator = _coordinator(hass)
+    hw = _HardwareResult(io=12.5, p_io=10)
+    app = _ApplicationResult()
+
+    advice = coordinator._build_recommendations(hw, app)
+
+    assert any("I/O pressure" in line for line in advice)
+    assert any("12.5%" in line for line in advice)
+
+
+async def test_mixed_psi_and_classic_in_same_run(hass: HomeAssistant) -> None:
+    """CPU can use PSI while RAM falls back to classic in the same refresh."""
+    coordinator = _coordinator(hass)
+    hw = _HardwareResult(
+        cpu=8.0,
+        p_cpu=10,
+        cpu_used_psi=True,
+        ram=82.0,
+        p_ram=15,
+        ram_used_psi=False,
+    )
+    app = _ApplicationResult()
+
+    advice = coordinator._build_recommendations(hw, app)
+
+    joined = "\n".join(advice)
+    assert "PSI CPU stall time" in joined
+    assert "Memory utilization" in joined
+
+
+async def test_no_advice_when_all_clear(hass: HomeAssistant) -> None:
+    """Empty hardware/application result produces an empty advice list.
+
+    The coordinator's main update path turns the empty list into REC_ALL_CLEAR
+    when populating the recommendations attribute.
+    """
+    coordinator = _coordinator(hass)
+    hw = _HardwareResult()
+    app = _ApplicationResult()
+
+    advice = coordinator._build_recommendations(hw, app)
+
+    assert advice == []
+    # Smoke check the all-clear constant is still importable + non-empty.
+    assert REC_ALL_CLEAR

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,0 +1,183 @@
+"""Tests for the update-pending pillar, including the 7-day grace (#26)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haghs.const import (
+    DATA_UPDATE_FIRST_SEEN,
+    DOMAIN,
+    UPDATE_GRACE_DAYS,
+)
+from custom_components.haghs.coordinator import HaghsDataUpdateCoordinator
+
+
+def _coordinator(hass: HomeAssistant) -> HaghsDataUpdateCoordinator:
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    return HaghsDataUpdateCoordinator(hass, entry)
+
+
+def _set_first_seen(
+    hass: HomeAssistant,
+    entity_id: str,
+    days_ago: float,
+) -> None:
+    """Force the recorded first-seen timestamp for an update entity."""
+    hass.data.setdefault(DOMAIN, {}).setdefault(DATA_UPDATE_FIRST_SEEN, {})[entity_id] = (
+        dt_util.utcnow() - timedelta(days=days_ago)
+    )
+
+
+# ============================================================================
+# Grace-period semantics (#26)
+# ============================================================================
+
+
+async def test_freshly_pending_update_does_not_count(hass: HomeAssistant) -> None:
+    """A newly-pending update is recorded but does not contribute to penalty.
+
+    Reproduces the request from #26: most users install updates within a
+    few days, so the integration should not flag those as a health issue.
+    """
+    coordinator = _coordinator(hass)
+    hass.states.async_set("update.esphome", "on", {"friendly_name": "ESPHome"})
+
+    _p_backup, update_count, p_updates, _p_core_lag, pending = coordinator._calc_updates()
+
+    assert update_count == 0
+    assert p_updates == 0
+    assert pending == ["ESPHome"]
+    assert "update.esphome" in coordinator._update_first_seen
+
+
+async def test_update_past_grace_counts(hass: HomeAssistant) -> None:
+    """An update pending for longer than UPDATE_GRACE_DAYS is counted."""
+    coordinator = _coordinator(hass)
+    hass.states.async_set("update.esphome", "on", {"friendly_name": "ESPHome"})
+    _set_first_seen(hass, "update.esphome", days_ago=UPDATE_GRACE_DAYS + 1)
+
+    _p_backup, update_count, p_updates, _p_core_lag, pending = coordinator._calc_updates()
+
+    assert update_count == 1
+    assert p_updates == 5
+    assert pending == ["ESPHome"]
+
+
+async def test_update_within_grace_still_pending_but_uncounted(
+    hass: HomeAssistant,
+) -> None:
+    """6-day-old update still shows in pending_updates but stays uncounted."""
+    coordinator = _coordinator(hass)
+    hass.states.async_set("update.esphome", "on", {"friendly_name": "ESPHome"})
+    _set_first_seen(hass, "update.esphome", days_ago=UPDATE_GRACE_DAYS - 1)
+
+    _p_backup, update_count, _p_updates, _p_core_lag, pending = coordinator._calc_updates()
+
+    assert update_count == 0
+    assert pending == ["ESPHome"]
+
+
+async def test_mixed_ages_only_counts_past_grace(hass: HomeAssistant) -> None:
+    """Two old + one fresh update yields update_count == 2."""
+    coordinator = _coordinator(hass)
+    hass.states.async_set("update.a", "on", {"friendly_name": "A"})
+    hass.states.async_set("update.b", "on", {"friendly_name": "B"})
+    hass.states.async_set("update.c", "on", {"friendly_name": "C"})
+    _set_first_seen(hass, "update.a", days_ago=UPDATE_GRACE_DAYS + 5)
+    _set_first_seen(hass, "update.b", days_ago=UPDATE_GRACE_DAYS + 1)
+    # update.c gets a fresh timestamp during the run.
+
+    _p_backup, update_count, _p_updates, _p_core_lag, pending = coordinator._calc_updates()
+
+    assert update_count == 2
+    assert set(pending) == {"A", "B", "C"}
+
+
+# ============================================================================
+# Pruning + persistence
+# ============================================================================
+
+
+async def test_installed_update_is_pruned_from_tracker(hass: HomeAssistant) -> None:
+    """When an update is installed (state != 'on'), its timestamp is dropped."""
+    coordinator = _coordinator(hass)
+    _set_first_seen(hass, "update.esphome", days_ago=UPDATE_GRACE_DAYS + 1)
+    hass.states.async_set("update.esphome", "off")
+
+    coordinator._calc_updates()
+
+    assert "update.esphome" not in coordinator._update_first_seen
+
+
+async def test_first_seen_dict_survives_coordinator_reload(
+    hass: HomeAssistant,
+) -> None:
+    """A reloaded coordinator picks up the existing first-seen baseline."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    first = HaghsDataUpdateCoordinator(hass, entry)
+    _set_first_seen(hass, "update.esphome", days_ago=UPDATE_GRACE_DAYS + 1)
+
+    second = HaghsDataUpdateCoordinator(hass, entry)
+    assert first._update_first_seen is second._update_first_seen
+    assert "update.esphome" in second._update_first_seen
+
+
+# ============================================================================
+# Ignore label / pattern integration
+# ============================================================================
+
+
+async def test_ignore_pattern_excludes_update(hass: HomeAssistant) -> None:
+    """An update entity matching an ignore pattern is dropped before tracking."""
+    from custom_components.haghs.const import CONF_IGNORE_PATTERNS
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IGNORE_PATTERNS: ["update.iot_*"]},
+    )
+    entry.add_to_hass(hass)
+
+    hass.states.async_set("update.iot_bulb", "on", {"friendly_name": "Bulb"})
+    hass.states.async_set("update.core", "on", {"friendly_name": "Core"})
+
+    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    _set_first_seen(hass, "update.core", days_ago=UPDATE_GRACE_DAYS + 1)
+    coordinator._update_first_seen = hass.data[DOMAIN][DATA_UPDATE_FIRST_SEEN]
+
+    _p_backup, update_count, _p_updates, _p_core_lag, pending = coordinator._calc_updates()
+
+    assert update_count == 1
+    assert pending == ["Core"]
+    assert "update.iot_bulb" not in coordinator._update_first_seen
+
+
+# ============================================================================
+# Backup pillar sanity (lives in the same function)
+# ============================================================================
+
+
+async def test_stale_backup_yields_30_point_penalty(hass: HomeAssistant) -> None:
+    """binary_sensor.backups_stale = 'on' produces p_backup = 30."""
+    coordinator = _coordinator(hass)
+    hass.states.async_set("binary_sensor.backups_stale", "on")
+
+    p_backup, _update_count, _p_updates, _p_core_lag, _pending = coordinator._calc_updates()
+
+    assert p_backup == 30
+
+
+async def test_fresh_backup_yields_no_penalty(hass: HomeAssistant) -> None:
+    """binary_sensor.backups_stale = 'off' or absent leaves p_backup = 0."""
+    coordinator = _coordinator(hass)
+    hass.states.async_set("binary_sensor.backups_stale", "off")
+
+    p_backup, *_ = coordinator._calc_updates()
+
+    assert p_backup == 0

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -181,3 +181,44 @@ async def test_fresh_backup_yields_no_penalty(hass: HomeAssistant) -> None:
     p_backup, *_ = coordinator._calc_updates()
 
     assert p_backup == 0
+
+
+async def test_disabled_update_entity_is_excluded(hass: HomeAssistant) -> None:
+    """A disabled update entity is excluded from count, pending and tracking.
+
+    Reproduces the community report applied to updates: disabling the
+    entity in the registry must be enough to silence the penalty, no
+    haghs_ignore label required. Also matches the intent of #70
+    (wontfix for a global firmware-update flag) for individual entities.
+    """
+    from homeassistant.helpers import entity_registry as er
+
+    entity_registry = er.async_get(hass)
+    disabled = entity_registry.async_get_or_create(
+        "update",
+        "device_platform",
+        "unique_disabled_update",
+        suggested_object_id="device_firmware",
+    )
+    entity_registry.async_update_entity(
+        disabled.entity_id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+    enabled = entity_registry.async_get_or_create(
+        "update",
+        "device_platform",
+        "unique_enabled_update",
+        suggested_object_id="core",
+    )
+
+    coordinator = _coordinator(hass)
+    hass.states.async_set(disabled.entity_id, "on", {"friendly_name": "Firmware"})
+    hass.states.async_set(enabled.entity_id, "on", {"friendly_name": "Core"})
+    _set_first_seen(hass, disabled.entity_id, days_ago=UPDATE_GRACE_DAYS + 1)
+    _set_first_seen(hass, enabled.entity_id, days_ago=UPDATE_GRACE_DAYS + 1)
+
+    _p_backup, update_count, _p_updates, _p_core_lag, pending = coordinator._calc_updates()
+
+    assert update_count == 1
+    assert pending == ["Core"]
+    assert disabled.entity_id not in coordinator._update_first_seen

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -726,3 +726,109 @@ async def test_per_domain_only_counts_actual_zombies(hass: HomeAssistant) -> Non
 
     assert zombie_count == 2
     assert per_domain == {"cover": 1, "lock": 1}
+
+
+# ============================================================================
+# Configurable grace periods
+# ============================================================================
+
+
+async def test_custom_zombie_grace_minutes_shortens_window(
+    hass: HomeAssistant,
+) -> None:
+    """A user-set 5-minute zombie grace flags a 10-min-old zombie."""
+    from custom_components.haghs.const import CONF_ZOMBIE_GRACE_MINUTES
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_ZOMBIE_GRACE_MINUTES: 5})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.aggressive", age_minutes=10)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+
+
+async def test_custom_zombie_grace_minutes_extends_window(
+    hass: HomeAssistant,
+) -> None:
+    """A user-set 30-minute zombie grace skips a 20-min-old zombie."""
+    from custom_components.haghs.const import CONF_ZOMBIE_GRACE_MINUTES
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_ZOMBIE_GRACE_MINUTES: 30})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.tolerant", age_minutes=20)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+
+
+async def test_custom_battery_grace_minutes_used_for_battery_class(
+    hass: HomeAssistant,
+) -> None:
+    """The battery grace knob applies to device_class=battery only."""
+    from custom_components.haghs.const import CONF_BATTERY_GRACE_MINUTES
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_BATTERY_GRACE_MINUTES: 120})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.battery_90m", age_minutes=90, device_class="battery")
+    _make_zombie(hass, "sensor.normal_90m", age_minutes=90)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
+
+    # Battery sensor still inside its custom 120 min window; normal sensor
+    # passes the default 15 min window and is flagged.
+    assert zombie_count == 1
+
+
+async def test_default_grace_values_match_constants(
+    hass: HomeAssistant,
+) -> None:
+    """A coordinator with no overrides uses the documented default windows."""
+    from custom_components.haghs.const import (
+        DEFAULT_BATTERY_GRACE_MINUTES,
+        DEFAULT_ZOMBIE_GRACE_MINUTES,
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    coordinator = _coordinator_with_boot_age(hass, entry)
+
+    assert coordinator._zombie_grace_seconds == DEFAULT_ZOMBIE_GRACE_MINUTES * 60
+    assert coordinator._battery_grace_seconds == DEFAULT_BATTERY_GRACE_MINUTES * 60
+
+
+async def test_battery_grace_can_be_set_below_zombie_grace(
+    hass: HomeAssistant,
+) -> None:
+    """Option C: both knobs are independent. Battery < zombie is allowed."""
+    from custom_components.haghs.const import (
+        CONF_BATTERY_GRACE_MINUTES,
+        CONF_ZOMBIE_GRACE_MINUTES,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ZOMBIE_GRACE_MINUTES: 60,
+            CONF_BATTERY_GRACE_MINUTES: 10,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    # 30 minutes is past battery (10) but inside zombie (60).
+    _make_zombie(hass, "sensor.battery_30m", age_minutes=30, device_class="battery")
+    _make_zombie(hass, "sensor.normal_30m", age_minutes=30)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
+
+    # Only the battery sensor: 30 > 10, while normal sensor is still inside
+    # its 60 min window.
+    assert zombie_count == 1

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -519,3 +519,64 @@ async def test_non_battery_zombie_still_uses_15min_window(
 
     assert zombie_count == 1
     assert p_zombie > 0
+
+
+# ============================================================================
+# Disabled entity exclusion (community feedback)
+# ============================================================================
+
+
+async def test_disabled_entity_is_not_a_zombie(hass: HomeAssistant) -> None:
+    """An entity disabled via the registry is excluded without needing a label.
+
+    Reproduces the community report: disabling an entity in
+    'Settings > Devices & Services' should be enough; users should not
+    have to also add the haghs_ignore label.
+    """
+    entity_registry = er.async_get(hass)
+    entry_obj = entity_registry.async_get_or_create(
+        "sensor",
+        "test_platform",
+        "unique_disabled",
+        suggested_object_id="disabled_sensor",
+    )
+    entity_registry.async_update_entity(
+        entry_obj.entity_id,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, entry_obj.entity_id, age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+    assert p_zombie == 0
+
+
+async def test_hidden_entity_is_still_tracked(hass: HomeAssistant) -> None:
+    """hidden_by is intentionally NOT an ignore signal — only disabled_by is."""
+    entity_registry = er.async_get(hass)
+    entry_obj = entity_registry.async_get_or_create(
+        "sensor",
+        "test_platform",
+        "unique_hidden",
+        suggested_object_id="hidden_sensor",
+    )
+    entity_registry.async_update_entity(
+        entry_obj.entity_id,
+        hidden_by=er.RegistryEntryHider.USER,
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, entry_obj.entity_id, age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.haghs.const import DOMAIN
+from custom_components.haghs.const import DATA_BOOT_TIME, DOMAIN
 from custom_components.haghs.coordinator import HaghsDataUpdateCoordinator
 
 
@@ -22,6 +22,28 @@ def _make_zombie(hass: HomeAssistant, entity_id: str, age_minutes: int = 30) -> 
     hass.states.async_set(entity_id, STATE_UNAVAILABLE)
     state = hass.states.get(entity_id)
     state.last_changed = dt_util.utcnow() - timedelta(minutes=age_minutes)
+
+
+def _coordinator_with_boot_age(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    boot_age_minutes: int = 60,
+) -> HaghsDataUpdateCoordinator:
+    """Create a coordinator with a boot-time baseline N minutes in the past.
+
+    By default we simulate "HA booted an hour ago" so any state with
+    last_changed in the last hour is treated as post-boot and the natural
+    15-minute grace period applies.
+    """
+    hass.data.setdefault(DOMAIN, {})[DATA_BOOT_TIME] = dt_util.utcnow() - timedelta(
+        minutes=boot_age_minutes
+    )
+    return HaghsDataUpdateCoordinator(hass, entry)
+
+
+# ============================================================================
+# Denominator semantics (#9)
+# ============================================================================
 
 
 async def test_denominator_uses_zombie_domains_only(hass: HomeAssistant) -> None:
@@ -39,7 +61,7 @@ async def test_denominator_uses_zombie_domains_only(hass: HomeAssistant) -> None
     for i in range(50):
         hass.states.async_set(f"automation.test_{i}", "on")
 
-    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    coordinator = _coordinator_with_boot_age(hass, entry)
     _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
 
     assert zombie_count == 1
@@ -58,7 +80,7 @@ async def test_denominator_zero_when_no_zombie_domain_states(
     for i in range(10):
         hass.states.async_set(f"script.y_{i}", "off")
 
-    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    coordinator = _coordinator_with_boot_age(hass, entry)
     _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
 
     assert zombie_count == 0
@@ -75,7 +97,7 @@ async def test_denominator_ignores_non_zombie_domains(hass: HomeAssistant) -> No
     _make_zombie(hass, "sensor.zombie_one")
     _make_zombie(hass, "sensor.zombie_two")
 
-    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    coordinator = _coordinator_with_boot_age(hass, entry)
     _zombie_list, p_zombie_baseline, zombie_count = coordinator._calc_zombies()
 
     assert zombie_count == 2
@@ -90,6 +112,11 @@ async def test_denominator_ignores_non_zombie_domains(hass: HomeAssistant) -> No
     assert p_zombie_after == p_zombie_baseline
 
 
+# ============================================================================
+# Grace periods (#10 + existing 15-minute window)
+# ============================================================================
+
+
 async def test_grace_period_still_active(hass: HomeAssistant) -> None:
     """Entities unavailable for less than 15 minutes are still ignored."""
     entry = MockConfigEntry(domain=DOMAIN, data={})
@@ -99,8 +126,84 @@ async def test_grace_period_still_active(hass: HomeAssistant) -> None:
         hass.states.async_set(f"sensor.healthy_{i}", "100")
     _make_zombie(hass, "sensor.recent", age_minutes=5)
 
-    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    coordinator = _coordinator_with_boot_age(hass, entry)
     _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
 
     assert zombie_count == 0
     assert p_zombie == 0
+
+
+async def test_restart_grace_skips_recently_restored_state(
+    hass: HomeAssistant,
+) -> None:
+    """A 2-hour-old last_changed is ignored within 15 min of HA boot.
+
+    Reproduces #10: after a restart, last_changed is restored from the
+    recorder and predates the boot. Without this fix the entity would be
+    flagged as a zombie immediately.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(5):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+    _make_zombie(hass, "sensor.restored", age_minutes=120)
+
+    coordinator = _coordinator_with_boot_age(hass, entry, boot_age_minutes=5)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+    assert p_zombie == 0
+
+
+async def test_restart_grace_releases_after_15_minutes(hass: HomeAssistant) -> None:
+    """After 15 min post-boot, restored zombies are flagged again."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(5):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+    _make_zombie(hass, "sensor.restored", age_minutes=120)
+
+    coordinator = _coordinator_with_boot_age(hass, entry, boot_age_minutes=30)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert p_zombie > 0
+
+
+async def test_post_boot_grace_uses_last_changed(hass: HomeAssistant) -> None:
+    """For entities that went unavailable after boot, last_changed wins."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(5):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+    # HA booted 60 min ago, sensor went unavailable 5 min ago. Effective
+    # baseline is the (newer) last_changed, so the standard grace applies.
+    _make_zombie(hass, "sensor.recent_after_boot", age_minutes=5)
+
+    coordinator = _coordinator_with_boot_age(hass, entry, boot_age_minutes=60)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+    assert p_zombie == 0
+
+
+# ============================================================================
+# hass.data persistence
+# ============================================================================
+
+
+async def test_boot_time_persists_across_coordinator_reloads(
+    hass: HomeAssistant,
+) -> None:
+    """Reloading the integration must not reset the boot-time baseline."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    first = HaghsDataUpdateCoordinator(hass, entry)
+    second = HaghsDataUpdateCoordinator(hass, entry)
+
+    assert first._boot_time == second._boot_time
+    assert hass.data[DOMAIN][DATA_BOOT_TIME] == first._boot_time

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -80,7 +80,7 @@ async def test_denominator_uses_zombie_domains_only(hass: HomeAssistant) -> None
         hass.states.async_set(f"automation.test_{i}", "on")
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert p_zombie == 20
@@ -99,7 +99,7 @@ async def test_denominator_zero_when_no_zombie_domain_states(
         hass.states.async_set(f"script.y_{i}", "off")
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 0
     assert p_zombie == 0
@@ -116,7 +116,7 @@ async def test_denominator_ignores_non_zombie_domains(hass: HomeAssistant) -> No
     _make_zombie(hass, "sensor.zombie_two")
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie_baseline, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie_baseline, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 2
     # Ratio = 2 / 12 ≈ 16.7 % → ceil(16.7 * 7) = 117 → capped at 20.
@@ -125,7 +125,7 @@ async def test_denominator_ignores_non_zombie_domains(hass: HomeAssistant) -> No
     # Inflate the instance with 200 non-zombie-domain entities.
     for i in range(200):
         hass.states.async_set(f"automation.bulk_{i}", "on")
-    _zombie_list, p_zombie_after, _zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie_after, _zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert p_zombie_after == p_zombie_baseline
 
@@ -145,7 +145,7 @@ async def test_grace_period_still_active(hass: HomeAssistant) -> None:
     _make_zombie(hass, "sensor.recent", age_minutes=5)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 0
     assert p_zombie == 0
@@ -168,7 +168,7 @@ async def test_restart_grace_skips_recently_restored_state(
     _make_zombie(hass, "sensor.restored", age_minutes=120)
 
     coordinator = _coordinator_with_boot_age(hass, entry, boot_age_minutes=5)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 0
     assert p_zombie == 0
@@ -184,7 +184,7 @@ async def test_restart_grace_releases_after_15_minutes(hass: HomeAssistant) -> N
     _make_zombie(hass, "sensor.restored", age_minutes=120)
 
     coordinator = _coordinator_with_boot_age(hass, entry, boot_age_minutes=30)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert p_zombie > 0
@@ -202,7 +202,7 @@ async def test_post_boot_grace_uses_last_changed(hass: HomeAssistant) -> None:
     _make_zombie(hass, "sensor.recent_after_boot", age_minutes=5)
 
     coordinator = _coordinator_with_boot_age(hass, entry, boot_age_minutes=60)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 0
     assert p_zombie == 0
@@ -224,7 +224,7 @@ async def test_zombies_skipped_during_startup(hass: HomeAssistant) -> None:
 
     hass.set_state(CoreState.starting)
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 0
     assert p_zombie == 0
@@ -243,7 +243,7 @@ async def test_zombies_detected_after_started_event(hass: HomeAssistant) -> None
     hass.set_state(CoreState.starting)
     coordinator = _coordinator_with_boot_age(hass, entry)
 
-    _zombie_list, _p, count_pre = coordinator._calc_zombies()
+    _zombie_list, _p, count_pre, _per_domain = coordinator._calc_zombies()
     assert count_pre == 0
 
     hass.set_state(CoreState.running)
@@ -251,7 +251,7 @@ async def test_zombies_detected_after_started_event(hass: HomeAssistant) -> None
     await hass.async_block_till_done()
 
     assert coordinator._registries_ready is True
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
     assert zombie_count == 1
     assert p_zombie > 0
 
@@ -282,7 +282,7 @@ async def test_unregistered_zombie_gets_prefix(hass: HomeAssistant) -> None:
     _make_zombie(hass, "sensor.ghost", age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+    zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert zombie_list == [f"{ATTR_UNREGISTERED_PREFIX}sensor.ghost"]
@@ -304,7 +304,7 @@ async def test_registered_zombie_has_no_prefix(hass: HomeAssistant) -> None:
     _make_zombie(hass, "sensor.real", age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+    zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert zombie_list == ["sensor.real"]
@@ -391,7 +391,7 @@ async def test_pattern_match_excludes_zombie(hass: HomeAssistant) -> None:
     _make_zombie(hass, "sensor.other", age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+    zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert zombie_list == [f"{ATTR_UNREGISTERED_PREFIX}sensor.other"]
@@ -413,7 +413,7 @@ async def test_pattern_match_excludes_registered_entity(hass: HomeAssistant) -> 
     _make_zombie(hass, "sensor.docker_cpu", age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, _p, zombie_count = coordinator._calc_zombies()
+    _zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 0
 
@@ -440,7 +440,7 @@ async def test_label_and_pattern_combined(hass: HomeAssistant) -> None:
     _make_zombie(hass, "sensor.real", age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+    zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert zombie_list == [f"{ATTR_UNREGISTERED_PREFIX}sensor.real"]
@@ -484,7 +484,7 @@ async def test_battery_zombie_within_60min_window_skipped(
     _make_zombie(hass, "sensor.battery_30m", age_minutes=30, device_class="battery")
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 0
     assert p_zombie == 0
@@ -500,7 +500,7 @@ async def test_battery_zombie_after_60min_window_counted(
     _make_zombie(hass, "sensor.battery_61m", age_minutes=61, device_class="battery")
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert p_zombie > 0
@@ -516,7 +516,7 @@ async def test_non_battery_zombie_still_uses_15min_window(
     _make_zombie(hass, "sensor.temp_30m", age_minutes=30, device_class="temperature")
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert p_zombie > 0
@@ -552,7 +552,7 @@ async def test_disabled_entity_is_not_a_zombie(hass: HomeAssistant) -> None:
     _make_zombie(hass, entry_obj.entity_id, age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 0
     assert p_zombie == 0
@@ -578,7 +578,7 @@ async def test_hidden_entity_is_still_tracked(hass: HomeAssistant) -> None:
     _make_zombie(hass, entry_obj.entity_id, age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, _p_zombie, zombie_count = coordinator._calc_zombies()
+    _zombie_list, _p_zombie, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
 
@@ -611,7 +611,7 @@ async def test_multiple_ignore_labels_match_any(hass: HomeAssistant) -> None:
     _make_zombie(hass, "sensor.real", age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+    zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
     assert zombie_list == [f"{ATTR_UNREGISTERED_PREFIX}sensor.real"]
@@ -633,6 +633,96 @@ async def test_empty_ignore_labels_list_acts_as_no_label(
     _make_zombie(hass, labelled.entity_id, age_minutes=60)
 
     coordinator = _coordinator_with_boot_age(hass, entry)
-    _zombie_list, _p, zombie_count = coordinator._calc_zombies()
+    _zombie_list, _p, zombie_count, _per_domain = coordinator._calc_zombies()
 
     assert zombie_count == 1
+
+
+# ============================================================================
+# Domain coverage + per-domain breakdown + cap (Z2M expansion)
+# ============================================================================
+
+
+async def test_newly_included_domains_are_detected(hass: HomeAssistant) -> None:
+    """Entities in domains added during the Z2M expansion become zombies."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "cover.living_room_blinds", age_minutes=30)
+    _make_zombie(hass, "lock.front_door", age_minutes=30)
+    _make_zombie(hass, "select.fan_mode", age_minutes=30)
+    _make_zombie(hass, "number.target_temperature", age_minutes=30)
+    _make_zombie(hass, "valve.garden_irrigation", age_minutes=30)
+    _make_zombie(hass, "humidifier.bedroom", age_minutes=30)
+    _make_zombie(hass, "siren.alarm", age_minutes=30)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p, zombie_count, per_domain = coordinator._calc_zombies()
+
+    assert zombie_count == 7
+    assert per_domain == {
+        "cover": 1,
+        "lock": 1,
+        "select": 1,
+        "number": 1,
+        "valve": 1,
+        "humidifier": 1,
+        "siren": 1,
+    }
+
+
+async def test_button_unknown_state_is_never_a_zombie(hass: HomeAssistant) -> None:
+    """Buttons default to state=unknown and must not be flagged as zombies.
+
+    Regression guard: if someone re-adds `button` to ZOMBIE_DOMAINS, every
+    freshly-installed Zigbee/MQTT button would become a false positive.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "button.unpressed_zigbee_button", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, p_zombie, zombie_count, per_domain = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+    assert p_zombie == 0
+    assert per_domain == {}
+
+
+async def test_zombie_list_capped_but_count_and_per_domain_are_full(
+    hass: HomeAssistant,
+) -> None:
+    """zombie_entities is capped at ZOMBIE_LIST_CAP; count + per_domain are not."""
+    from custom_components.haghs.const import ZOMBIE_LIST_CAP
+
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(ZOMBIE_LIST_CAP + 25):
+        _make_zombie(hass, f"sensor.bulk_{i}", age_minutes=30)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    zombie_list, _p, zombie_count, per_domain = coordinator._calc_zombies()
+
+    assert len(zombie_list) == ZOMBIE_LIST_CAP
+    assert zombie_count == ZOMBIE_LIST_CAP + 25
+    assert per_domain == {"sensor": ZOMBIE_LIST_CAP + 25}
+
+
+async def test_per_domain_only_counts_actual_zombies(hass: HomeAssistant) -> None:
+    """Healthy entities and entities still inside the grace window do not count."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(3):
+        hass.states.async_set(f"cover.healthy_{i}", "open")
+    _make_zombie(hass, "cover.recent", age_minutes=5)
+    _make_zombie(hass, "cover.gone", age_minutes=30)
+    _make_zombie(hass, "lock.also_gone", age_minutes=30)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p, zombie_count, per_domain = coordinator._calc_zombies()
+
+    assert zombie_count == 2
+    assert per_domain == {"cover": 1, "lock": 1}

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -368,16 +368,6 @@ def test_compile_patterns_translates_glob() -> None:
     assert not compiled[1].match("binary_sensor.test_12")
 
 
-def test_compile_patterns_skips_invalid_with_warning(caplog) -> None:
-    """An invalid pattern is logged but does not break the rest."""
-    with caplog.at_level("WARNING"):
-        compiled = _compile_patterns(["sensor.[unclosed", "sensor.ok_*"])
-
-    assert len(compiled) == 1
-    assert compiled[0].match("sensor.ok_one")
-    assert "Invalid ignore pattern" in caplog.text
-
-
 async def test_pattern_match_excludes_zombie(hass: HomeAssistant) -> None:
     """An entity matching a configured glob is not counted as a zombie."""
     entry = MockConfigEntry(

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -188,6 +188,67 @@ async def test_post_boot_grace_uses_last_changed(hass: HomeAssistant) -> None:
 
     assert zombie_count == 0
     assert p_zombie == 0
+
+
+# ============================================================================
+# Registry-race fix (#13)
+# ============================================================================
+
+
+async def test_zombies_skipped_during_startup(hass: HomeAssistant) -> None:
+    """During HA startup, zombie detection returns empty even with matches."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(3):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+    _make_zombie(hass, "sensor.battery", age_minutes=60)
+
+    hass.set_state(CoreState.starting)
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+    assert p_zombie == 0
+    assert coordinator._registries_ready is False
+
+
+async def test_zombies_detected_after_started_event(hass: HomeAssistant) -> None:
+    """After EVENT_HOMEASSISTANT_STARTED fires, zombie detection resumes."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(3):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+    _make_zombie(hass, "sensor.battery", age_minutes=60)
+
+    hass.set_state(CoreState.starting)
+    coordinator = _coordinator_with_boot_age(hass, entry)
+
+    _zombie_list, _p, count_pre = coordinator._calc_zombies()
+    assert count_pre == 0
+
+    hass.set_state(CoreState.running)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+
+    assert coordinator._registries_ready is True
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+    assert zombie_count == 1
+    assert p_zombie > 0
+
+
+async def test_registries_ready_immediately_when_already_running(
+    hass: HomeAssistant,
+) -> None:
+    """If HA is already running at coordinator init, no listener is needed."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    # The hass fixture is in CoreState.running by default.
+    coordinator = _coordinator_with_boot_age(hass, entry)
+
+    assert coordinator._registries_ready is True
 
 
 # ============================================================================

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -12,6 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.haghs.const import (
     ATTR_UNREGISTERED_PREFIX,
+    CONF_IGNORE_LABELS,
     CONF_IGNORE_PATTERNS,
     DATA_BOOT_TIME,
     DOMAIN,
@@ -428,7 +429,7 @@ async def test_label_and_pattern_combined(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            "ignore_label": "haghs_ignore",
+            CONF_IGNORE_LABELS: ["haghs_ignore"],
             CONF_IGNORE_PATTERNS: ["sensor.torque_*"],
         },
     )
@@ -578,5 +579,60 @@ async def test_hidden_entity_is_still_tracked(hass: HomeAssistant) -> None:
 
     coordinator = _coordinator_with_boot_age(hass, entry)
     _zombie_list, _p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+
+
+# ============================================================================
+# Multi-label support (Phase A)
+# ============================================================================
+
+
+async def test_multiple_ignore_labels_match_any(hass: HomeAssistant) -> None:
+    """An entity carrying any of the configured ignore labels is excluded."""
+    entity_registry = er.async_get(hass)
+    labelled_a = entity_registry.async_get_or_create(
+        "sensor", "p", "ml_a", suggested_object_id="ml_a"
+    )
+    entity_registry.async_update_entity(labelled_a.entity_id, labels={"haghs_ignore"})
+    labelled_b = entity_registry.async_get_or_create(
+        "sensor", "p", "ml_b", suggested_object_id="ml_b"
+    )
+    entity_registry.async_update_entity(labelled_b.entity_id, labels={"vacation"})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IGNORE_LABELS: ["haghs_ignore", "vacation"]},
+    )
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, labelled_a.entity_id, age_minutes=60)
+    _make_zombie(hass, labelled_b.entity_id, age_minutes=60)
+    _make_zombie(hass, "sensor.real", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert zombie_list == [f"{ATTR_UNREGISTERED_PREFIX}sensor.real"]
+
+
+async def test_empty_ignore_labels_list_acts_as_no_label(
+    hass: HomeAssistant,
+) -> None:
+    """An empty ignore_labels list does not exclude anything."""
+    entity_registry = er.async_get(hass)
+    labelled = entity_registry.async_get_or_create(
+        "sensor", "p", "ml_empty", suggested_object_id="labelled"
+    )
+    entity_registry.async_update_entity(labelled.entity_id, labels={"haghs_ignore"})
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_IGNORE_LABELS: []})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, labelled.entity_id, age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p, zombie_count = coordinator._calc_zombies()
 
     assert zombie_count == 1

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -6,10 +6,15 @@ from datetime import timedelta
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE
 from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.haghs.const import DATA_BOOT_TIME, DOMAIN
+from custom_components.haghs.const import (
+    ATTR_UNREGISTERED_PREFIX,
+    DATA_BOOT_TIME,
+    DOMAIN,
+)
 from custom_components.haghs.coordinator import HaghsDataUpdateCoordinator
 
 
@@ -249,6 +254,82 @@ async def test_registries_ready_immediately_when_already_running(
     coordinator = _coordinator_with_boot_age(hass, entry)
 
     assert coordinator._registries_ready is True
+
+
+# ============================================================================
+# Ghost marker (#6)
+# ============================================================================
+
+
+async def test_unregistered_zombie_gets_prefix(hass: HomeAssistant) -> None:
+    """Zombies without an entity-registry entry are tagged in the list."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.ghost", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert zombie_list == [f"{ATTR_UNREGISTERED_PREFIX}sensor.ghost"]
+
+
+async def test_registered_zombie_has_no_prefix(hass: HomeAssistant) -> None:
+    """Zombies that have an entity-registry entry keep their plain id."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "sensor",
+        "test_platform",
+        "unique_id_1",
+        suggested_object_id="real",
+    )
+
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.real", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert zombie_list == ["sensor.real"]
+
+
+async def test_ghost_warning_logged_once_per_entity(hass: HomeAssistant, caplog) -> None:
+    """The 'unregistered zombie' warning is emitted at most once per id."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.ghost_one", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+
+    with caplog.at_level("WARNING"):
+        coordinator._calc_zombies()
+        coordinator._calc_zombies()
+        coordinator._calc_zombies()
+
+    occurrences = caplog.text.count("Detected unregistered zombie entity")
+    assert occurrences == 1
+
+
+async def test_ghost_warning_logged_per_distinct_entity(hass: HomeAssistant, caplog) -> None:
+    """Distinct ghost entities each produce one warning."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.ghost_a", age_minutes=60)
+    _make_zombie(hass, "sensor.ghost_b", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+
+    with caplog.at_level("WARNING"):
+        coordinator._calc_zombies()
+
+    assert "sensor.ghost_a" in caplog.text
+    assert "sensor.ghost_b" in caplog.text
 
 
 # ============================================================================

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -12,10 +12,14 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.haghs.const import (
     ATTR_UNREGISTERED_PREFIX,
+    CONF_IGNORE_PATTERNS,
     DATA_BOOT_TIME,
     DOMAIN,
 )
-from custom_components.haghs.coordinator import HaghsDataUpdateCoordinator
+from custom_components.haghs.coordinator import (
+    HaghsDataUpdateCoordinator,
+    _compile_patterns,
+)
 
 
 def _make_zombie(hass: HomeAssistant, entity_id: str, age_minutes: int = 30) -> None:
@@ -330,6 +334,107 @@ async def test_ghost_warning_logged_per_distinct_entity(hass: HomeAssistant, cap
 
     assert "sensor.ghost_a" in caplog.text
     assert "sensor.ghost_b" in caplog.text
+
+
+# ============================================================================
+# Pattern-based ignore (#64)
+# ============================================================================
+
+
+def test_compile_patterns_returns_empty_for_none_or_empty() -> None:
+    """An absent or empty pattern list compiles to an empty list."""
+    assert _compile_patterns(None) == []
+    assert _compile_patterns([]) == []
+    assert _compile_patterns([""]) == []
+
+
+def test_compile_patterns_translates_glob() -> None:
+    """Valid glob patterns compile to regex objects that match entity ids."""
+    compiled = _compile_patterns(["sensor.docker_*", "binary_sensor.test_?"])
+    assert len(compiled) == 2
+    assert compiled[0].match("sensor.docker_cpu")
+    assert compiled[0].match("sensor.docker_mem")
+    assert not compiled[0].match("sensor.other_cpu")
+    assert compiled[1].match("binary_sensor.test_1")
+    assert not compiled[1].match("binary_sensor.test_12")
+
+
+def test_compile_patterns_skips_invalid_with_warning(caplog) -> None:
+    """An invalid pattern is logged but does not break the rest."""
+    with caplog.at_level("WARNING"):
+        compiled = _compile_patterns(["sensor.[unclosed", "sensor.ok_*"])
+
+    assert len(compiled) == 1
+    assert compiled[0].match("sensor.ok_one")
+    assert "Invalid ignore pattern" in caplog.text
+
+
+async def test_pattern_match_excludes_zombie(hass: HomeAssistant) -> None:
+    """An entity matching a configured glob is not counted as a zombie."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IGNORE_PATTERNS: ["sensor.docker_*"]},
+    )
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.docker_cpu", age_minutes=60)
+    _make_zombie(hass, "sensor.docker_mem", age_minutes=60)
+    _make_zombie(hass, "sensor.other", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert zombie_list == [f"{ATTR_UNREGISTERED_PREFIX}sensor.other"]
+
+
+async def test_pattern_match_excludes_registered_entity(hass: HomeAssistant) -> None:
+    """Patterns also work for registered entities (no label needed)."""
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "sensor", "docker_platform", "unique_1", suggested_object_id="docker_cpu"
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_IGNORE_PATTERNS: ["sensor.docker_*"]},
+    )
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.docker_cpu", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, _p, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+
+
+async def test_label_and_pattern_combined(hass: HomeAssistant) -> None:
+    """Label + pattern are evaluated together; either match excludes."""
+    entity_registry = er.async_get(hass)
+    label_entry = entity_registry.async_get_or_create(
+        "sensor", "p", "labelled", suggested_object_id="labelled"
+    )
+    entity_registry.async_update_entity(label_entry.entity_id, labels={"haghs_ignore"})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "ignore_label": "haghs_ignore",
+            CONF_IGNORE_PATTERNS: ["sensor.torque_*"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.labelled", age_minutes=60)
+    _make_zombie(hass, "sensor.torque_speed", age_minutes=60)
+    _make_zombie(hass, "sensor.real", age_minutes=60)
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    zombie_list, _p, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert zombie_list == [f"{ATTR_UNREGISTERED_PREFIX}sensor.real"]
 
 
 # ============================================================================

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -22,13 +22,21 @@ from custom_components.haghs.coordinator import (
 )
 
 
-def _make_zombie(hass: HomeAssistant, entity_id: str, age_minutes: int = 30) -> None:
+def _make_zombie(
+    hass: HomeAssistant,
+    entity_id: str,
+    age_minutes: int = 30,
+    *,
+    device_class: str | None = None,
+) -> None:
     """Set an entity to STATE_UNAVAILABLE with last_changed in the past.
 
     The grace period in _calc_zombies skips entities changed less than 15
-    minutes ago, so age_minutes must exceed 15 for the entity to be counted.
+    minutes ago (60 minutes for device_class=battery), so age_minutes must
+    exceed the relevant window for the entity to be counted.
     """
-    hass.states.async_set(entity_id, STATE_UNAVAILABLE)
+    attrs = {"device_class": device_class} if device_class is not None else {}
+    hass.states.async_set(entity_id, STATE_UNAVAILABLE, attrs)
     state = hass.states.get(entity_id)
     state.last_changed = dt_util.utcnow() - timedelta(minutes=age_minutes)
 
@@ -454,3 +462,60 @@ async def test_boot_time_persists_across_coordinator_reloads(
 
     assert first._boot_time == second._boot_time
     assert hass.data[DOMAIN][DATA_BOOT_TIME] == first._boot_time
+
+
+# ============================================================================
+# Battery grace (#62)
+# ============================================================================
+
+
+async def test_battery_zombie_within_60min_window_skipped(
+    hass: HomeAssistant,
+) -> None:
+    """A battery-class sensor unavailable for 30 min is still inside its grace.
+
+    Reproduces #62: Zigbee/Homematic battery devices often re-poll on a
+    multi-minute cycle, so the standard 15 min window flagged them as zombies.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.battery_30m", age_minutes=30, device_class="battery")
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+    assert p_zombie == 0
+
+
+async def test_battery_zombie_after_60min_window_counted(
+    hass: HomeAssistant,
+) -> None:
+    """After the extended battery window expires, the entity is flagged."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.battery_61m", age_minutes=61, device_class="battery")
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert p_zombie > 0
+
+
+async def test_non_battery_zombie_still_uses_15min_window(
+    hass: HomeAssistant,
+) -> None:
+    """The extended window applies only to device_class=battery."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    _make_zombie(hass, "sensor.temp_30m", age_minutes=30, device_class="temperature")
+
+    coordinator = _coordinator_with_boot_age(hass, entry)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert p_zombie > 0

--- a/tests/test_zombies.py
+++ b/tests/test_zombies.py
@@ -1,0 +1,106 @@
+"""Tests for the zombie pillar calculation."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.haghs.const import DOMAIN
+from custom_components.haghs.coordinator import HaghsDataUpdateCoordinator
+
+
+def _make_zombie(hass: HomeAssistant, entity_id: str, age_minutes: int = 30) -> None:
+    """Set an entity to STATE_UNAVAILABLE with last_changed in the past.
+
+    The grace period in _calc_zombies skips entities changed less than 15
+    minutes ago, so age_minutes must exceed 15 for the entity to be counted.
+    """
+    hass.states.async_set(entity_id, STATE_UNAVAILABLE)
+    state = hass.states.get(entity_id)
+    state.last_changed = dt_util.utcnow() - timedelta(minutes=age_minutes)
+
+
+async def test_denominator_uses_zombie_domains_only(hass: HomeAssistant) -> None:
+    """Ratio is computed against ZOMBIE_DOMAINS entity count, not total states.
+
+    Pre-fix: 1 zombie / 56 total states ≈ 1.8 % → p_zombie ≈ 13.
+    Post-fix: 1 zombie / 6 zombie-domain sensors ≈ 16.7 % → p_zombie capped at 20.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(5):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+    _make_zombie(hass, "sensor.zombie_one")
+    for i in range(50):
+        hass.states.async_set(f"automation.test_{i}", "on")
+
+    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 1
+    assert p_zombie == 20
+
+
+async def test_denominator_zero_when_no_zombie_domain_states(
+    hass: HomeAssistant,
+) -> None:
+    """An instance with no entities in ZOMBIE_DOMAINS yields p_zombie = 0."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(20):
+        hass.states.async_set(f"automation.x_{i}", "on")
+    for i in range(10):
+        hass.states.async_set(f"script.y_{i}", "off")
+
+    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+    assert p_zombie == 0
+
+
+async def test_denominator_ignores_non_zombie_domains(hass: HomeAssistant) -> None:
+    """Adding many non-zombie-domain states does not lower the penalty."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(10):
+        hass.states.async_set(f"sensor.ok_{i}", "100")
+    _make_zombie(hass, "sensor.zombie_one")
+    _make_zombie(hass, "sensor.zombie_two")
+
+    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    _zombie_list, p_zombie_baseline, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 2
+    # Ratio = 2 / 12 ≈ 16.7 % → ceil(16.7 * 7) = 117 → capped at 20.
+    assert p_zombie_baseline == 20
+
+    # Inflate the instance with 200 non-zombie-domain entities.
+    for i in range(200):
+        hass.states.async_set(f"automation.bulk_{i}", "on")
+    _zombie_list, p_zombie_after, _zombie_count = coordinator._calc_zombies()
+
+    assert p_zombie_after == p_zombie_baseline
+
+
+async def test_grace_period_still_active(hass: HomeAssistant) -> None:
+    """Entities unavailable for less than 15 minutes are still ignored."""
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+
+    for i in range(5):
+        hass.states.async_set(f"sensor.healthy_{i}", "100")
+    _make_zombie(hass, "sensor.recent", age_minutes=5)
+
+    coordinator = HaghsDataUpdateCoordinator(hass, entry)
+    _zombie_list, p_zombie, zombie_count = coordinator._calc_zombies()
+
+    assert zombie_count == 0
+    assert p_zombie == 0

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -94,6 +94,43 @@ re-running it is safe.
 - `tests/test_migration.py` — updated to assert against the dynamic
   `_CONFIG_VERSION` and a new "already at current version" no-op case
 
+### PSI-aware recommendation text for CPU and RAM (#8)
+
+**Problem:** Two community reports flagged that `"CPU load is impacting
+score (6.5%)"` was being read as 6.5 % CPU utilization, when in fact the
+value is the PSI stall-time percentage. Users who saw 38 % in System
+Monitor and 6.5 % in the HAGHS Advisor concluded the integration was
+reacting to the wrong value. The same ambiguity exists for the RAM
+recommendation.
+
+**Fix:** `REC_CPU_LOAD` and `REC_RAM_PRESSURE` have been split into two
+variants each:
+- `REC_CPU_LOAD_PSI` — "PSI CPU stall time is impacting score (X%)"
+- `REC_CPU_LOAD_CLASSIC` — "CPU utilization is impacting score (X%)"
+- `REC_RAM_PRESSURE_PSI` / `REC_RAM_PRESSURE_CLASSIC` analogously.
+
+The hardware pillar now tracks `cpu_used_psi` and `ram_used_psi` on
+`_HardwareResult` per metric, so the variant is chosen on a per-metric
+basis (CPU could be PSI while RAM is classic in mixed setups). The IO
+recommendation is unchanged because IO has no classic fallback in HAGHS.
+
+**User-facing text drift:** Existing recommendation text changes. The
+attribute name `recommendations` is unchanged, no scoring change, no
+config-flow change. Dashboards parsing the text literally should update
+to the new wording or — better — wait for the boolean attributes coming
+with #11.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — four new templates, old
+  `REC_CPU_LOAD` / `REC_RAM_PRESSURE` removed
+- `custom_components/haghs/coordinator.py` — `_HardwareResult` gains
+  `cpu_used_psi` and `ram_used_psi`, set from `psi.cpu is not None` and
+  `psi.memory is not None`; `_build_recommendations` picks the right
+  variant
+- `tests/test_recommendations.py` — new, with PSI vs classic for CPU
+  and RAM, IO smoke test, mixed PSI/classic in the same run, and empty
+  advice for an all-clear result
+
 ## Bug Fixes
 
 ### Hard cap: app score never reaches 100 while zombies exist (#7)

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -51,6 +51,27 @@ labels.
 
 ## Bug Fixes
 
+### Zombie grace period after HA restart
+
+**Problem:** After a HA restart, states are restored from the recorder along
+with their historical `last_changed` timestamps. An entity that was
+`unavailable` for 2 hours before shutdown ends up with `last_changed = "2 h
+ago"` immediately on boot, so the existing 15-minute grace period was bypassed
+and the entity counted as a zombie right after every restart.
+
+**Fix:** `_calc_zombies()` now uses `max(state.last_changed, boot_time)` as
+the baseline for the grace check. The boot-time anchor is captured the first
+time the coordinator initialises in a HA process and stored in `hass.data`,
+so it survives integration reloads. Within ~15 minutes of boot, restored
+zombies are ignored; afterwards the regular ratio penalty applies again.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `DATA_BOOT_TIME` key
+- `custom_components/haghs/coordinator.py` — boot-time capture in `__init__`,
+  `effective_seen` baseline in `_calc_zombies()`
+- `tests/test_zombies.py` — new restart-grace cases plus a regression test
+  that the boot baseline is shared across coordinator reloads
+
 ### Zombie penalty denominator now counts only ZOMBIE_DOMAINS
 
 **Problem:** `p_zombie` was computed as `zombie_count / total_states`, where

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -94,6 +94,49 @@ re-running it is safe.
 - `tests/test_migration.py` — updated to assert against the dynamic
   `_CONFIG_VERSION` and a new "already at current version" no-op case
 
+### Boolean recommendation flags as state attributes (#11)
+
+**Problem:** Dashboard cards and external integrations had to parse the
+`recommendations` string to react to individual advisor states. That made
+templates brittle and version-sensitive every time the wording changed
+(see #8).
+
+**Fix:** The sensor now exposes ten boolean attributes alongside the
+existing `recommendations` string. Each flag mirrors one trigger
+condition of `_build_recommendations`:
+
+```
+rec_cpu_load
+rec_ram_pressure
+rec_io_pressure
+rec_disk_low
+rec_db_over_limit
+rec_power_unstable
+rec_backup_stale
+rec_updates_pending
+rec_zombie
+rec_core_lag
+```
+
+Cards can check `state_attr(sensor.system_ha_global_health_score,
+'rec_zombie')` directly. The key set is exported as `REC_FLAG_KEYS` in
+`const.py` so tests and external consumers have a single source of
+truth; the sensor forwards them via a comprehension. No existing
+attribute was renamed or removed — the change is purely additive.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `REC_FLAG_KEYS` tuple
+- `custom_components/haghs/coordinator.py` — `_is_disk_low_sd`,
+  `_is_disk_low_ssd` helpers (extracted from `_build_recommendations`),
+  new `_build_rec_flags` method, flags merged into `_async_update_data`
+  return dict
+- `custom_components/haghs/sensor.py` — forwards every `REC_FLAG_KEYS`
+  entry into `extra_state_attributes`
+- `tests/test_recommendations.py` — all flags False on empty result,
+  key set matches `REC_FLAG_KEYS`, hardware and application penalties
+  flip the right flags, SD-card / SSD / plenty-of-space cases for the
+  combined `rec_disk_low`
+
 ### PSI-aware recommendation text for CPU and RAM (#8)
 
 **Problem:** Two community reports flagged that `"CPU load is impacting

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -430,9 +430,22 @@ Added README coverage for the new v2.3 surface area:
   invalid-pattern WARNING behaviour.
 - Sensor Attributes table gained the ten `rec_*` boolean flags so
   dashboard authors can find them in one place.
+- `psi_available` description in the Sensor Attributes table rewritten
+  to match `_PsiData.available` semantics: True only when both CPU and
+  memory PSI are present. Clarifies that I/O PSI is read independently
+  and that Disk is always `psutil`-based, never PSI.
 
 **Files changed:** `README.md` — Label Configuration + Sensor Attributes
 sections.
+
+### `sensor.py` imports `HaghsDataUpdateCoordinator` from `.coordinator`
+
+Replaces `from . import HaghsDataUpdateCoordinator` with a direct import
+from the `coordinator` module. Removes the implicit re-export path
+through `__init__.py` and matches the recommendation R1 from the PR #49
+review thread. No runtime behaviour change.
+
+**Files changed:** `custom_components/haghs/sensor.py`.
 
 ## Tests
 

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -191,13 +191,14 @@ alphabetically with a comment documenting the selection rule:
 `media_player`, `number`, `remote`, `select`, `sensor`, `siren`,
 `switch`, `text`, `vacuum`, `valve`, `water_heater`.
 
-**Bewusst draussen:** `button` und `event`. Beide haben `unknown`
-als Default-State (Button noch nie gedrückt → `unknown`), Aufnahme
-würde jeden frisch installierten Button als Zombie melden. Helpers
-(`input_*`, `counter`, `timer`), Logik-Entities (`automation`,
-`script`, `scene`), HA-interne Domains (`person`, `zone`, `group`,
-`sun`) und Cloud-lastige Domains (`weather`, `calendar`) bleiben
-ebenfalls draussen.
+**Deliberately excluded:** `button` and `event`. Both default to
+`unknown` (a button that has never been pressed reports `unknown`),
+so including them would false-positive every freshly installed
+button. Helpers (`input_*`, `counter`, `timer`), logic entities
+(`automation`, `script`, `scene`), HA-internal domains (`person`,
+`zone`, `group`, `sun`) and cloud-heavy domains (`weather`,
+`calendar`) are excluded for the same kind of reason — their
+`unavailable` / `unknown` is not a hardware-health signal.
 
 **New attribute `zombie_count_per_domain`:** A small `dict[str, int]`
 that always reflects the **full** zombie count grouped by domain,

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -9,7 +9,7 @@ All changes on the `dev` branch relative to `main` (v2.2.2).
 Auto-detect under-voltage conditions on Raspberry Pi devices. When `binary_sensor.rpi_power_status` reports a problem, a flat 20-point penalty is applied to the hardware score. No user configuration required — the check is skipped automatically on non-RPi hardware.
 
 **Files changed:**
-- `custom_components/haghs/__init__.py` — Added power supply check in `_async_calc_hardware()`, extended `_HardwareResult` with `p_power`, added recommendation in `_build_recommendations()`
+- `custom_components/haghs/coordinator.py` — Added power supply check in `_async_calc_hardware()`, extended `_HardwareResult` with `p_power`, added recommendation in `_build_recommendations()` *(originally landed in `__init__.py`; relocated by the PR #49 refactor in the same release)*
 - `custom_components/haghs/const.py` — Added `REC_POWER_UNSTABLE` recommendation template
 
 ### Config flow refactor + RepairsFlow for missing fallback sensors (#49)
@@ -94,12 +94,12 @@ re-running it is safe.
 - `tests/test_migration.py` — updated to assert against the dynamic
   `_CONFIG_VERSION` and a new "already at current version" no-op case
 
-### Boolean recommendation flags as state attributes (#11)
+### Boolean recommendation flags as state attributes
 
 **Problem:** Dashboard cards and external integrations had to parse the
 `recommendations` string to react to individual advisor states. That made
 templates brittle and version-sensitive every time the wording changed
-(see #8).
+(see the PSI-aware recommendation text section below).
 
 **Fix:** The sensor now exposes ten boolean attributes alongside the
 existing `recommendations` string. Each flag mirrors one trigger
@@ -137,7 +137,7 @@ attribute was renamed or removed — the change is purely additive.
   flip the right flags, SD-card / SSD / plenty-of-space cases for the
   combined `rec_disk_low`
 
-### PSI-aware recommendation text for CPU and RAM (#8)
+### PSI-aware recommendation text for CPU and RAM
 
 **Problem:** Two community reports flagged that `"CPU load is impacting
 score (6.5%)"` was being read as 6.5 % CPU utilization, when in fact the
@@ -160,8 +160,8 @@ recommendation is unchanged because IO has no classic fallback in HAGHS.
 **User-facing text drift:** Existing recommendation text changes. The
 attribute name `recommendations` is unchanged, no scoring change, no
 config-flow change. Dashboards parsing the text literally should update
-to the new wording or — better — wait for the boolean attributes coming
-with #11.
+to the new wording or — better — switch to the new boolean recommendation
+flag attributes introduced in this release.
 
 **Files changed:**
 - `custom_components/haghs/const.py` — four new templates, old
@@ -215,7 +215,7 @@ every time the radio came back.
 `state.attributes.device_class`: 60 minutes for `battery`, the existing
 15 minutes for everything else. Reading the device class from the state
 attributes works for both registered and unregistered entities, so the
-fix covers ghost zombies (#6) too.
+fix covers unregistered ghost zombies (#61) too.
 
 **Files changed:**
 - `custom_components/haghs/const.py` — `ZOMBIE_GRACE_SECONDS = 900`,
@@ -226,7 +226,7 @@ fix covers ghost zombies (#6) too.
   counted, non-battery 30 min still counted (regression for the
   standard window)
 
-### Hard cap: app score never reaches 100 while zombies exist (#7)
+### Hard cap: app score never reaches 100 while zombies exist (#61)
 
 **Problem:** The recorder config bonus (+10) could fully negate a small
 ratio-based zombie penalty on large instances, returning `app_score = 100`
@@ -254,7 +254,7 @@ them back to 100. Documented per the backward-compatibility rule.
   when a single zombie meets a full bonus, score 100 still possible
   without zombies, cap does not inflate naturally low scores
 
-### Surface unregistered "ghost" zombies in the attribute (#6)
+### Surface unregistered "ghost" zombies in the attribute (#61)
 
 **Problem:** Entities that exist in HA's state machine but have no entry in
 the entity registry were correctly counted as zombies but were invisible
@@ -275,7 +275,7 @@ same as registered zombies for `zombie_count` and `p_zombie`.
 - `tests/test_zombies.py` — registered vs unregistered formatting,
   log-once-per-id, distinct ghosts each warned
 
-### Defer zombie detection until HA finishes startup (#13)
+### Defer zombie detection until HA finishes startup (#62)
 
 **Problem:** A user reported that battery sensors reappeared in the
 `zombie_entities` attribute after a full system restart even though the
@@ -298,7 +298,7 @@ restart-grace fix above: restart-grace handles the recorder-restored
 - `tests/test_zombies.py` — startup-skip, post-`EVENT_HOMEASSISTANT_STARTED`
   resumption, and immediate-readiness when HA is already running
 
-### Zombie grace period after HA restart
+### Zombie grace period after HA restart (#27)
 
 **Problem:** After a HA restart, states are restored from the recorder along
 with their historical `last_changed` timestamps. An entity that was
@@ -319,7 +319,7 @@ zombies are ignored; afterwards the regular ratio penalty applies again.
 - `tests/test_zombies.py` — new restart-grace cases plus a regression test
   that the boot baseline is shared across coordinator reloads
 
-### Zombie penalty denominator now counts only ZOMBIE_DOMAINS
+### Zombie penalty denominator now counts only ZOMBIE_DOMAINS (#9)
 
 **Problem:** `p_zombie` was computed as `zombie_count / total_states`, where
 `total_states` came from `hass.states.async_all()` and therefore included
@@ -335,8 +335,8 @@ the state machine.
 **Score drift:** Users with mostly sensor entities see roughly the same score.
 Users with large numbers of automations or scripts may see a higher zombie
 penalty that more accurately reflects the share of unhealthy sensor-class
-entities. Score 100 is still only achievable with zero zombies once the
-hard cap from #61 lands.
+entities. Score 100 remains only achievable with zero zombies thanks to the
+hard cap from #61 (separate entry above).
 
 **Files changed:**
 - `custom_components/haghs/coordinator.py` — `_calc_zombies()`
@@ -411,7 +411,7 @@ Lite card now matches that.
 
 **Files changed:** `README.md` — HAGHS Lite YAML block.
 
-### Config-audit tips in both cards (#12)
+### Config-audit tips in both cards (#67)
 
 A new "💡 Tips to improve your score" block appears in both the Lite
 and Pro cards when `recorder_keep_days` is unset or
@@ -428,8 +428,8 @@ Added README coverage for the new v2.3 surface area:
 - Label Configuration section gained a *Pattern-Based Ignore* subsection
   documenting `ignore_patterns` (#64) with glob examples and the
   invalid-pattern WARNING behaviour.
-- Sensor Attributes table gained the ten `rec_*` boolean flags (#11)
-  so dashboard authors can find them in one place.
+- Sensor Attributes table gained the ten `rec_*` boolean flags so
+  dashboard authors can find them in one place.
 
 **Files changed:** `README.md` — Label Configuration + Sensor Attributes
 sections.
@@ -449,7 +449,7 @@ follow. Coverage:
 - `hardware_score <= 80` whenever `p_power == 20`, asserting the
   penalty is wired into the hardware-pillar averaging.
 - `REC_POWER_UNSTABLE` appears in the advice list when power is
-  flagged, and `rec_power_unstable` boolean attribute (#11) mirrors
+  flagged, and the `rec_power_unstable` boolean attribute mirrors
   that state.
 
 Closes the third phase of #54. Phase 1 (infrastructure) and phase 2

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -349,13 +349,41 @@ external-database and FAQ sections.
 Issue #65 was closed as *wontfix* — the YAML samples in the README are
 card-level configuration and must be added via *Add Card → Manual* on a
 dashboard, not pasted into the raw dashboard editor (which expects a full
-`views:` structure). A short note will be added to the *UI Integration*
-intro in the upcoming Phase 4 README pass.
+`views:` structure).
 
-> Independent finding from this review: the Lite card has an empty truthy
-> branch in the recommendations block (`{% if rec … %} {% else %} … {% endif %}`),
-> which means recommendations are never rendered. Tracked as a Phase 4 fix.
+### Lite card: render recommendations again (follow-up to #65)
+
+The HAGHS Lite card had an empty truthy branch in the recommendations
+block, so the card always fell through to the all-clear message even
+when the `recommendations` attribute carried active warnings. The Pro
+card already prints the value via `{{ rec }}` in the same shape; the
+Lite card now matches that.
+
+**Files changed:** `README.md` — HAGHS Lite YAML block.
+
+### Config-audit tips in both cards (#12)
+
+A new "💡 Tips to improve your score" block appears in both the Lite
+and Pro cards when `recorder_keep_days` is unset or
+`recorder_filter_active` is false, listing which Config Audit bonus
+points are not yet earned (+5 pts each). Users below 100 points with
+no active advisor warnings now have an actionable explanation. No
+integration code change — both attributes were already exposed.
+
+**Files changed:** `README.md` — HAGHS Lite + HAGHS Pro YAML.
+
+### Documentation for v2.3 features
+
+Added README coverage for the new v2.3 surface area:
+- Label Configuration section gained a *Pattern-Based Ignore* subsection
+  documenting `ignore_patterns` (#64) with glob examples and the
+  invalid-pattern WARNING behaviour.
+- Sensor Attributes table gained the ten `rec_*` boolean flags (#11)
+  so dashboard authors can find them in one place.
+
+**Files changed:** `README.md` — Label Configuration + Sensor Attributes
+sections.
 
 ---
 
-*Last updated: 2026-05-08*
+*Last updated: 2026-05-11*

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -51,6 +51,29 @@ labels.
 
 ## Bug Fixes
 
+### Defer zombie detection until HA finishes startup (#13)
+
+**Problem:** A user reported that battery sensors reappeared in the
+`zombie_entities` attribute after a full system restart even though the
+`haghs_ignore` label was correctly assigned. Likely cause: HAGHS evaluated
+zombies on its first refresh while the entity registry was still being
+restored from storage, so `entity_entry.labels` was empty for the affected
+entities and the ignore-label check found no match.
+
+**Fix:** The coordinator now exposes a `_registries_ready` flag that is
+`True` if `hass.is_running` at construction time. When the flag is `False`
+the coordinator subscribes to `EVENT_HOMEASSISTANT_STARTED` once and flips
+the flag from a `@callback`. `_calc_zombies()` returns an empty result
+while the flag is `False` and logs at debug level. This complements the
+restart-grace fix above: restart-grace handles the recorder-restored
+`last_changed`, the registry-race guard handles the labels.
+
+**Files changed:**
+- `custom_components/haghs/coordinator.py` — `_registries_ready` flag,
+  `_async_registries_ready` listener, early-return in `_calc_zombies`
+- `tests/test_zombies.py` — startup-skip, post-`EVENT_HOMEASSISTANT_STARTED`
+  resumption, and immediate-readiness when HA is already running
+
 ### Zombie grace period after HA restart
 
 **Problem:** After a HA restart, states are restored from the recorder along

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -51,6 +51,30 @@ labels.
 
 ## Bug Fixes
 
+### Zombie penalty denominator now counts only ZOMBIE_DOMAINS
+
+**Problem:** `p_zombie` was computed as `zombie_count / total_states`, where
+`total_states` came from `hass.states.async_all()` and therefore included
+domains that can never be zombies (`automation`, `script`, `person`, `zone`,
+`input_boolean`, …). Instances with many automations and few sensor entities
+were artificially under-penalised compared to pure-sensor setups for the same
+number of zombies.
+
+**Fix:** The denominator is now restricted to entities in `ZOMBIE_DOMAINS`,
+counted in the same loop as zombie detection so there is no extra pass over
+the state machine.
+
+**Score drift:** Users with mostly sensor entities see roughly the same score.
+Users with large numbers of automations or scripts may see a higher zombie
+penalty that more accurately reflects the share of unhealthy sensor-class
+entities. Score 100 is still only achievable with zero zombies once the
+hard cap from #61 lands.
+
+**Files changed:**
+- `custom_components/haghs/coordinator.py` — `_calc_zombies()`
+- `tests/test_zombies.py` — new, covering the new denominator semantics and
+  confirming the grace period is unaffected
+
 ### Ignore Label: TextSelector replaced with LabelSelector (#30)
 
 **Problem:** Custom ignore labels with special characters (e.g. `X:Warning:Ignore`) or different casing failed silently. The `TextSelector` stored the user-typed label *name*, but Home Assistant's entity/device registry uses slugified *label IDs* internally. A label named `X:Warning:Ignore` gets the ID `x_warning_ignore`, causing the comparison to always fail.

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -174,7 +174,57 @@ with #11.
   and RAM, IO smoke test, mixed PSI/classic in the same run, and empty
   advice for an all-clear result
 
+### 7-day update grace period (#26)
+
+**Problem:** `update_count` deducted 5 points per pending update entity as
+soon as the entity went `on`. Users who normally install updates within
+a few days saw their score drop and recover repeatedly, which is noise
+rather than a real health signal.
+
+**Fix:** `_calc_updates()` now records a first-seen timestamp per pending
+update entity in `hass.data[DOMAIN][DATA_UPDATE_FIRST_SEEN]` and only
+counts an entity toward the penalty after it has been pending for at
+least `UPDATE_GRACE_DAYS = 7`. Entities still appear in `pending_updates`
+immediately so users see what is queued; the `p_core_lag` penalty for
+HA Core lagging ≥ 3 minor versions is unchanged. Installed updates are
+pruned from the tracking dict on the next refresh.
+
+**Persistence note:** The tracking dict lives in `hass.data` (in-memory).
+On HA restart all timestamps reset, which intentionally re-grants the
+grace period — preferable to writing yet another small storage file.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `DATA_UPDATE_FIRST_SEEN`,
+  `UPDATE_GRACE_DAYS`
+- `custom_components/haghs/coordinator.py` — `_update_first_seen` dict
+  on the coordinator, age check + pruning in `_calc_updates()`
+- `tests/test_updates.py` — new file covering fresh / mid-grace / past-
+  grace updates, mixed-age set, pruning, reload persistence, ignore
+  pattern integration, and backup-pillar sanity
+
 ## Bug Fixes
+
+### Extended zombie grace for battery-class entities (#62)
+
+**Problem:** Zigbee/Homematic battery devices routinely take longer than
+15 minutes to re-poll after the coordinator restarts, so the standard
+zombie grace window flagged perfectly-healthy battery sensors as zombies
+every time the radio came back.
+
+**Fix:** `_calc_zombies()` now picks the grace window based on
+`state.attributes.device_class`: 60 minutes for `battery`, the existing
+15 minutes for everything else. Reading the device class from the state
+attributes works for both registered and unregistered entities, so the
+fix covers ghost zombies (#6) too.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `ZOMBIE_GRACE_SECONDS = 900`,
+  `BATTERY_GRACE_SECONDS = 3600`
+- `custom_components/haghs/coordinator.py` — per-entity grace selection
+  in `_calc_zombies()`
+- `tests/test_zombies.py` — battery 30 min skipped, battery 61 min
+  counted, non-battery 30 min still counted (regression for the
+  standard window)
 
 ### Hard cap: app score never reaches 100 while zombies exist (#7)
 

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -12,6 +12,43 @@ Auto-detect under-voltage conditions on Raspberry Pi devices. When `binary_senso
 - `custom_components/haghs/__init__.py` — Added power supply check in `_async_calc_hardware()`, extended `_HardwareResult` with `p_power`, added recommendation in `_build_recommendations()`
 - `custom_components/haghs/const.py` — Added `REC_POWER_UNSTABLE` recommendation template
 
+### Config flow refactor + RepairsFlow for missing fallback sensors (#49)
+
+Builds on the `LabelSelector` change (#30) and reshapes setup so that CPU and
+RAM sensors are only required when Linux PSI data is unavailable. When PSI is
+available the user no longer has to pick percentage sensors at all; HAGHS uses
+the host's stall-time data directly.
+
+**What changed:**
+- `coordinator.py` — extracted `HaghsDataUpdateCoordinator` from `__init__.py`
+  into its own module. No scoring logic changes.
+- `config_flow.py` — `_schema_with_psi()` builds the schema with optional
+  CPU/RAM when PSI is available, required otherwise. Schema definitions
+  (`FALLBACK_SENSORS_SCHEMA`, `_BASE_SCHEMA`, `_EXTRA_OPTIONS_SCHEMA`)
+  deduplicated between setup and options flow. Switched to
+  `add_suggested_values_to_schema()` and `UnitOfTime.SECONDS`.
+- `repairs.py` (new) — `MissingFallbackSensorRepairFlow` lets users supply
+  CPU/RAM sensors through the Repairs UI if PSI becomes unavailable post-setup
+  (e.g. after a Docker host change), without uninstalling/reinstalling.
+- `__init__.py` — gates setup on PSI-or-fallbacks. If both are missing,
+  raises `ConfigEntryError(translation_key="fallback_missing")` and creates a
+  fixable repair issue. Adds `async_migrate_entry` to migrate legacy text
+  ignore-label values to label IDs.
+- `const.py` — added `VersionInformation` (frozen dataclass for ordered
+  version comparison) and `IssueIds` (StrEnum of issue identifiers).
+- `strings.json` / `translations/en.json` — added `fallback_missing` issue
+  and exception, plus the repair-flow `confirm` step.
+
+**Bumps:** `VERSION = 3`, `MINOR_VERSION = 2`.
+
+**Migration:** `_migrate_ignore_label_value` rewrites legacy text labels to
+label IDs and is idempotent — already-migrated entries are detected via
+`label_registry.async_get_label(label_value)` and skipped, so future
+`_CONFIG_VERSION` bumps cannot re-run the conversion and create duplicate
+labels.
+
+**Co-authored-by:** [@gustavakerstrom](https://github.com/gustavakerstrom)
+
 ## Bug Fixes
 
 ### Ignore Label: TextSelector replaced with LabelSelector (#30)

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -51,6 +51,27 @@ labels.
 
 ## Bug Fixes
 
+### Surface unregistered "ghost" zombies in the attribute (#6)
+
+**Problem:** Entities that exist in HA's state machine but have no entry in
+the entity registry were correctly counted as zombies but were invisible
+through the HA UI, so users could not identify or resolve them. The
+`zombie_entities` attribute gave no hint that these entities were
+unregistered.
+
+**Fix:** Such entities are now prepended with `[unregistered] ` in the
+`zombie_entities` attribute, and a `WARNING` log entry is emitted once per
+entity id per coordinator instance so the entity id is searchable in
+*Settings > System > Logs*. Scoring is unchanged: ghost zombies count the
+same as registered zombies for `zombie_count` and `p_zombie`.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `ATTR_UNREGISTERED_PREFIX`
+- `custom_components/haghs/coordinator.py` — `_logged_ghost_entities`,
+  ghost branch in `_calc_zombies`
+- `tests/test_zombies.py` — registered vs unregistered formatting,
+  log-once-per-id, distinct ghosts each warned
+
 ### Defer zombie detection until HA finishes startup (#13)
 
 **Problem:** A user reported that battery sensors reappeared in the

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -174,6 +174,65 @@ flag attributes introduced in this release.
   and RAM, IO smoke test, mixed PSI/classic in the same run, and empty
   advice for an all-clear result
 
+### ZOMBIE_DOMAINS expanded to 22 device domains + per-domain breakdown
+
+**Problem (community report):** A user noticed that after upgrading
+Zigbee2MQTT (2.9.2 → 2.10.1) several Hue lights went `unknown`, but
+HAGHS never flagged them. Root cause: `ZOMBIE_DOMAINS` was a short
+nine-domain whitelist (`sensor`, `binary_sensor`, `switch`, `light`,
+`fan`, `climate`, `media_player`, `vacuum`, `camera`). Entities in
+`cover`, `lock`, `select`, `number`, `valve`, … were silently skipped.
+
+**Fix:** `ZOMBIE_DOMAINS` now covers 22 device-class domains, sorted
+alphabetically with a comment documenting the selection rule:
+
+`alarm_control_panel`, `binary_sensor`, `camera`, `climate`, `cover`,
+`device_tracker`, `fan`, `humidifier`, `lawn_mower`, `light`, `lock`,
+`media_player`, `number`, `remote`, `select`, `sensor`, `siren`,
+`switch`, `text`, `vacuum`, `valve`, `water_heater`.
+
+**Bewusst draussen:** `button` und `event`. Beide haben `unknown`
+als Default-State (Button noch nie gedrückt → `unknown`), Aufnahme
+würde jeden frisch installierten Button als Zombie melden. Helpers
+(`input_*`, `counter`, `timer`), Logik-Entities (`automation`,
+`script`, `scene`), HA-interne Domains (`person`, `zone`, `group`,
+`sun`) und Cloud-lastige Domains (`weather`, `calendar`) bleiben
+ebenfalls draussen.
+
+**New attribute `zombie_count_per_domain`:** A small `dict[str, int]`
+that always reflects the **full** zombie count grouped by domain,
+even when the `zombie_entities` list itself is truncated. Dashboards
+can render a per-domain breakdown to identify which integration is
+producing the outage (e.g. `{"sensor": 12, "light": 8, "cover": 4}`).
+
+**Listing cap raised:** `zombie_entities` cap raised from 20 to 100
+entries via the new `ZOMBIE_LIST_CAP` constant. The HA state machine
+caps each attribute payload at 16 KB; 100 entity ids with the
+`[unregistered] ` prefix accounted for stay well below that. The
+`zombie_count` and the new per-domain dict always carry the full
+totals, the cap only applies to the listing.
+
+**Score drift:** Users with entities in the newly covered domains
+that have been `unavailable` / `unknown` past the grace window now
+see their score reflect that. Documented per the
+backward-compatibility rule in `HAGHS_PHILOSOPHY.md`. Adding an
+ignore label, an ignore pattern, or disabling the entity restores
+the previous score immediately.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `ZOMBIE_LIST_CAP = 100`
+- `custom_components/haghs/coordinator.py` — `ZOMBIE_DOMAINS` rewritten
+  to 22 entries with a selection-rule comment; `_calc_zombies` now
+  also returns a `zombie_per_domain` dict and uses the new constant
+  for capping; `_ApplicationResult` carries the new field; data dict
+  in `_async_update_data` exposes `zombie_count_per_domain`
+- `custom_components/haghs/sensor.py` — forwards
+  `zombie_count_per_domain` into `extra_state_attributes`
+- `tests/test_zombies.py` — existing tuple unpacks updated to the
+  new 4-tuple; four new tests covering newly included domains,
+  `button.unknown` regression guard, list-cap behaviour with
+  truthful count, and per-domain accuracy with mixed grace status
+
 ### Multiple ignore labels + dynamic toggling via HA-native services
 
 **Problem (community feedback):** HAGHS' ignore mechanism accepted only

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -49,6 +49,51 @@ labels.
 
 **Co-authored-by:** [@gustavakerstrom](https://github.com/gustavakerstrom)
 
+### Pattern-based ignore for entities without unique IDs (#64)
+
+**Problem:** Integrations such as `monitor_docker` and the legacy `torque`
+sensor create entities without a unique ID. Those entities exist only in
+the state machine, have no entity-registry entry, and therefore cannot
+carry a label. Users had no way to exclude them from zombie detection or
+pending-update penalties.
+
+**Fix:** A new optional `ignore_patterns` field accepts a list of glob
+patterns matched against `entity_id` (e.g. `sensor.docker_*`). Patterns
+are compiled once during coordinator init via `fnmatch.translate`;
+invalid patterns are skipped with a `WARNING` so a single typo does not
+disable the rest. The matching is centralised in a new `_is_ignored()`
+helper that consolidates the three exclusion sources in a documented
+order: pattern match → label on entity → label on device.
+
+**Behaviour change:** `_calc_updates()` previously honoured only the
+ignore label on the entity itself. It now also respects device-level
+labels and the new patterns via the shared `_is_ignored()` helper, so
+the exclusion behaviour is consistent across the zombie and update
+pillars.
+
+**Migration:** `_CONFIG_VERSION` bumped to (3, 3). The migration is a
+no-op for v3.2 entries beyond the version stamp; `async_migrate_entry`
+now early-returns when the entry is already at the current version, so
+re-running it is safe.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `CONF_IGNORE_PATTERNS`,
+  `_CONFIG_VERSION` (moved from `config_flow.py`, bumped to 3.3)
+- `custom_components/haghs/config_flow.py` — `TextSelector(multiple=True)`
+  in the schema; imports `_CONFIG_VERSION` from `const`
+- `custom_components/haghs/coordinator.py` — `_compile_patterns()`,
+  `_is_ignored()`, ignore patterns wired into `_calc_zombies` and
+  `_calc_updates`
+- `custom_components/haghs/__init__.py` — `async_migrate_entry` bumps to
+  `_CONFIG_VERSION` and early-returns at current version
+- `custom_components/haghs/strings.json` + `translations/en.json` —
+  field label and description for `ignore_patterns`
+- `tests/test_zombies.py` — `_compile_patterns` unit tests plus
+  pattern-match cases for `_calc_zombies` (including combined label +
+  pattern)
+- `tests/test_migration.py` — updated to assert against the dynamic
+  `_CONFIG_VERSION` and a new "already at current version" no-op case
+
 ## Bug Fixes
 
 ### Surface unregistered "ghost" zombies in the attribute (#6)

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -174,6 +174,58 @@ flag attributes introduced in this release.
   and RAM, IO smoke test, mixed PSI/classic in the same run, and empty
   advice for an all-clear result
 
+### Multiple ignore labels + dynamic toggling via HA-native services
+
+**Problem (community feedback):** HAGHS' ignore mechanism accepted only
+*one* label. Users with multiple exclusion contexts — e.g. a permanent
+`haghs_ignore` set plus a temporary `urlaub` (vacation) set — had to
+constantly re-tag entities back and forth. Watchman exposes a list and
+a dedicated service, which the reporter pointed at as the desired UX.
+
+**Fix:** The single `CONF_IGNORE_LABEL` field is replaced with the
+plural `CONF_IGNORE_LABELS` and rendered as a multi-select
+`LabelSelector(multiple=True)` in both Setup and Options flow. The
+shared `_is_ignored()` helper now matches entity/device labels against
+any configured label, so a single match excludes.
+
+**Dynamic toggling without a HAGHS-specific service:** Instead of
+adding a `haghs.set_ignore_labels` action, HAGHS relies on Home
+Assistant's existing `label.assign` and `label.remove` services. List
+the toggle labels (e.g. `vacation`) in the HAGHS *Ignore labels*
+field, then assign/remove the label from entities or devices from any
+automation. HAGHS picks up the change on its next refresh, no reload
+required. README documents the full pattern with a vacation example.
+
+**Migration:** `_CONFIG_VERSION` bumped to (3, 4). A new
+`_migrate_label_to_labels()` migration step runs for entries at
+`<= (3, 3)` and converts the legacy single value into the new list,
+removing the deprecated key. The step is idempotent and order-aware
+relative to the existing label-name → label-id rewrite from (3, 2):
+entries coming from 2.x are first slugified, then promoted to the
+list. `CONF_IGNORE_LABEL` remains defined in `const.py` for the
+migration code only.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `CONF_IGNORE_LABELS` added,
+  `CONF_IGNORE_LABEL` marked deprecated, `_CONFIG_VERSION` to (3, 4)
+- `custom_components/haghs/config_flow.py` — schema uses
+  `LabelSelector(multiple=True)` keyed by `CONF_IGNORE_LABELS`
+- `custom_components/haghs/coordinator.py` — `self.ignore_labels:
+  list[str]` and multi-match in `_is_ignored()`
+- `custom_components/haghs/__init__.py` — `async_migrate_entry` runs
+  the new (3, 3) → (3, 4) step; `_migrate_label_to_labels()` helper
+- `custom_components/haghs/strings.json` + `translations/en.json` —
+  plural field label and descriptions that point at `label.assign` /
+  `label.remove` for dynamic use
+- `README.md` — Label Configuration section rewritten with a working
+  automation example
+- `tests/test_migration.py` — new 3.3 → 3.4 migration test, existing
+  integration tests adjusted to assert on `CONF_IGNORE_LABELS`, four
+  new unit tests for `_migrate_label_to_labels`
+- `tests/test_zombies.py` — `test_label_and_pattern_combined`
+  switched to the plural key; two new tests for multi-label matching
+  and the empty-list no-op case
+
 ### 7-day update grace period (#26)
 
 **Problem:** `update_count` deducted 5 points per pending update entity as

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -368,6 +368,47 @@ grace period — preferable to writing yet another small storage file.
 
 ## Bug Fixes
 
+### Optional fields no longer revert after HA restart
+
+**Problem (community feedback):** A user reported that clearing the
+`db_sensor` field in the Options dialog "worked" only until the next
+Home Assistant restart, after which the originally (mis-)configured
+sensor reappeared. Investigation showed the same latent bug for every
+clearable optional field: `db_sensor`, `cpu_sensor`, `ram_sensor`,
+`ignore_labels`, and `ignore_patterns`.
+
+**Root cause:** `vol.Optional(KEY)` schema entries without a `default`
+produce a `user_input` dict that simply omits the key when the user
+leaves the field empty. The options handler passed `user_input` straight
+through to `async_create_entry`, so the omitted key never reached
+`entry.options`. The coordinator merges runtime config as
+`{**entry.data, **entry.options}` (`coordinator.py:218`), which means
+the original value from `entry.data` came back to life on the next
+boot — exactly what the user had tried to clear.
+
+**Fix:** A new `_normalize_optional()` helper in `config_flow.py`
+walks a tuple of nullable-optional keys before
+`async_create_entry` and forces every missing or falsy value to an
+explicit `None` (scalars) or `[]` (label / pattern lists). The
+normalization runs in both the initial config flow and the options
+flow, so the data format is consistent end-to-end.
+
+**Migration / user action:** No schema migration needed — the fix is
+forward-compatible. Users who are stuck on a wrong value just need to
+open the integration's *Configure* page once, leave the field empty,
+and click *Submit*. That writes an explicit `None` / `[]` into
+`entry.options`, which then correctly overrides `entry.data` on every
+restart.
+
+**Files changed:**
+- `custom_components/haghs/config_flow.py` — new
+  `_NULLABLE_OPTIONAL_KEYS` tuple, `_normalize_optional()` helper,
+  applied in `async_step_user` and `async_step_init`
+- `tests/test_options_flow.py` — new file: five regression tests
+  covering db, ignore labels, ignore patterns, CPU/RAM fallbacks
+  under PSI, and a positive case verifying that non-empty
+  submissions are not normalized away
+
 ### Registry-disabled entities are silently ignored
 
 **Problem (community feedback):** Disabling an entity in

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -368,6 +368,28 @@ grace period — preferable to writing yet another small storage file.
 
 ## Bug Fixes
 
+### Registry-race guard now actually defers during HA startup
+
+**Problem (discovered via the v2.3 test bootstrap):** The registry-race
+guard in `HaghsDataUpdateCoordinator.__init__` used `hass.is_running`
+to decide whether the entity registry was loaded. Home Assistant Core
+defines `is_running` as `state in (CoreState.starting, CoreState.running)`,
+so during the `starting` phase the guard saw `True`, skipped registering
+the `EVENT_HOMEASSISTANT_STARTED` listener, and `_calc_zombies` ran the
+full detection path before the entity registry (with ignore labels) was
+loaded from storage. The defer-during-startup behaviour described in
+the docstring and intended in #13 therefore never engaged within the
+narrow startup window where it matters.
+
+**Fix:** Replace `hass.is_running` with `hass.state == CoreState.running`.
+The guard now correctly evaluates to `False` while HA is `starting`,
+the listener is registered, detection is deferred, and `_async_registries_ready`
+fires on `EVENT_HOMEASSISTANT_STARTED` to enable detection cleanly.
+
+Surfaced by `tests/test_zombies.py::test_zombies_skipped_during_startup`
+and `test_zombies_detected_after_started_event`, both of which assert
+`coordinator._registries_ready is False` during `CoreState.starting`.
+
 ### Optional fields no longer revert after HA restart
 
 **Problem (community feedback):** A user reported that clearing the

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -96,6 +96,34 @@ re-running it is safe.
 
 ## Bug Fixes
 
+### Hard cap: app score never reaches 100 while zombies exist (#7)
+
+**Problem:** The recorder config bonus (+10) could fully negate a small
+ratio-based zombie penalty on large instances, returning `app_score = 100`
+even when zombies were actively reported in the `zombie_entities`
+attribute. This violates the transparency rule in `HAGHS_PHILOSOPHY.md`:
+a perfect score must reflect zero detected issues. Example from #61:
+3 zombies / 300 entities -> `p_zombie = 7`, with bonus `100 - 7 + 10`
+clamps to 100.
+
+**Fix:** After the existing `min(100, ...)` clamp in
+`_async_calc_application()`, an additional `if zombie_count > 0:
+app_final = min(99, app_final)` enforces the cap. Lower scores are
+untouched; only the boundary case where the calculation lands at 100 is
+pulled back to 99 when zombies are present.
+
+**Score drift:** Users with both detected zombies and a config bonus
+that previously pushed them to 100 will now see 99. Adding an ignore
+label (or pattern, #64) for entities they intentionally keep brings
+them back to 100. Documented per the backward-compatibility rule.
+
+**Files changed:**
+- `custom_components/haghs/coordinator.py` — `_async_calc_application()`
+  hard-cap line after the existing clamp
+- `tests/test_application.py` — new file with three cases: cap triggers
+  when a single zombie meets a full bonus, score 100 still possible
+  without zombies, cap does not inflate naturally low scores
+
 ### Surface unregistered "ghost" zombies in the attribute (#6)
 
 **Problem:** Entities that exist in HA's state machine but have no entry in

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -204,6 +204,39 @@ grace period — preferable to writing yet another small storage file.
 
 ## Bug Fixes
 
+### Registry-disabled entities are silently ignored
+
+**Problem (community feedback):** Disabling an entity in
+*Settings > Devices & Services > Entity > Disable entity* is the clearest
+"I don't want this entity active" signal Home Assistant provides, but
+HAGHS still flagged the entity as a zombie (or counted a disabled update
+toward the penalty) as long as the state machine kept the last
+`unavailable` / `unknown` value around. Users had to additionally apply
+the `haghs_ignore` label, which the reporter rightly called cumbersome.
+
+**Fix:** The shared `_is_ignored()` helper now early-returns `True` when
+`entity_entry.disabled_by` is not `None`, regardless of the source
+(`USER`, `INTEGRATION`, `CONFIG_ENTRY`, `DEVICE`, `HASS`). Because the
+helper is the single chokepoint for both `_calc_zombies` and
+`_calc_updates`, disabled entities now drop out of both pillars at once.
+
+`hidden_by` is intentionally **not** treated as ignore — hidden entities
+are still functional and a user may want HAGHS to keep watching them. To
+exclude a hidden entity, disable it instead or apply the ignore label.
+
+**Score drift:** Users with disabled entities that previously appeared
+in `zombie_entities` or `pending_updates` will see their score rise.
+Per the backward-compatibility rule in `HAGHS_PHILOSOPHY.md`, documented
+here; no scoring formula change.
+
+**Files changed:**
+- `custom_components/haghs/coordinator.py` — `_is_ignored()` gets a new
+  cheapest-first `disabled_by` check ahead of patterns + labels
+- `tests/test_zombies.py` — disabled entity not counted as zombie;
+  regression test that `hidden_by=USER` is still tracked
+- `tests/test_updates.py` — disabled update entity excluded from
+  `update_count`, `pending_updates` and the first-seen tracker
+
 ### Extended zombie grace for battery-class entities (#62)
 
 **Problem:** Zigbee/Homematic battery devices routinely take longer than

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -174,6 +174,58 @@ flag attributes introduced in this release.
   and RAM, IO smoke test, mixed PSI/classic in the same run, and empty
   advice for an all-clear result
 
+### Configurable zombie + battery grace periods
+
+**Problem:** The grace windows that decide *when* an `unavailable` /
+`unknown` entity becomes a zombie were hardcoded — 15 minutes for the
+general case, 60 minutes for `device_class: battery`. Users with a fast
+home network and short outages want a tighter window; users with
+sleeping tablets, seasonal devices, or quirky integrations want a more
+lenient one. Either way, there was no way to tune it without forking the
+code.
+
+**Fix:** Both windows are now user-configurable in the Options Flow,
+not the initial setup (they are runtime knobs, not setup prerequisites).
+Two new `NumberSelector` fields:
+
+- **Zombie grace period** (`zombie_grace_minutes`, default **15**,
+  range **1–240**) — the general window for all zombie-domain entities.
+- **Battery-class grace period** (`battery_grace_minutes`, default
+  **60**, range **1–240**) — the separate window used only when an
+  entity carries `device_class: battery` (Zigbee / Homematic radios
+  routinely take longer to re-poll those devices).
+
+Both knobs are independent (Option C from the design discussion):
+setting `battery_grace_minutes` lower than `zombie_grace_minutes`
+effectively turns the battery extension off, which is supported on
+purpose.
+
+**Backward compatibility:** No `_CONFIG_VERSION` bump. The new fields
+are optional with documented defaults that match the previous
+hardcoded values, so existing config entries behave identically until
+the user opens the Options Flow and changes them.
+
+**Files changed:**
+- `custom_components/haghs/const.py` — `CONF_ZOMBIE_GRACE_MINUTES`,
+  `CONF_BATTERY_GRACE_MINUTES`, `DEFAULT_ZOMBIE_GRACE_MINUTES = 15`,
+  `DEFAULT_BATTERY_GRACE_MINUTES = 60`; removed the old
+  `ZOMBIE_GRACE_SECONDS` / `BATTERY_GRACE_SECONDS` constants
+- `custom_components/haghs/config_flow.py` — two `NumberSelector`
+  entries in `_EXTRA_OPTIONS_SCHEMA` with `UnitOfTime.MINUTES`
+- `custom_components/haghs/coordinator.py` — reads the values once at
+  init into `self._zombie_grace_seconds` and `self._battery_grace_seconds`
+  (minutes * 60), uses them in `_calc_zombies` instead of the constants
+- `custom_components/haghs/strings.json` + `translations/en.json` —
+  field labels and detailed descriptions that explain the trade-off
+  and call out the battery defaults explicitly
+- `README.md` — *Options Flow (Runtime Settings)* section lists the
+  new fields with their defaults and ranges
+- `tests/test_zombies.py` — five new tests covering: shorter custom
+  zombie grace catches a zombie earlier; longer custom zombie grace
+  hides one; custom battery grace applies only to `device_class:
+  battery`; default constants match the documented values; battery
+  grace can be set below zombie grace without raising.
+
 ### ZOMBIE_DOMAINS expanded to 22 device domains + per-domain breakdown
 
 **Problem (community report):** A user noticed that after upgrading

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -384,6 +384,27 @@ Added README coverage for the new v2.3 surface area:
 **Files changed:** `README.md` — Label Configuration + Sensor Attributes
 sections.
 
+## Tests
+
+### Pilot pillar suite: power supply (#54 phase 3)
+
+First per-pillar test file landed: `tests/test_hardware_power.py` is
+the golden-input/output template that future pillar suites should
+follow. Coverage:
+
+- `p_power == 0` when the `binary_sensor.rpi_power_status` entity does
+  not exist (non-RPi hardware path).
+- `p_power == 20` when the entity reports `on` (under-voltage).
+- `p_power == 0` for the `off`, `unavailable` and `unknown` states.
+- `hardware_score <= 80` whenever `p_power == 20`, asserting the
+  penalty is wired into the hardware-pillar averaging.
+- `REC_POWER_UNSTABLE` appears in the advice list when power is
+  flagged, and `rec_power_unstable` boolean attribute (#11) mirrors
+  that state.
+
+Closes the third phase of #54. Phase 1 (infrastructure) and phase 2
+(migration tests) landed in earlier commits.
+
 ---
 
 *Last updated: 2026-05-11*

--- a/v2.3_CHANGELOG.md
+++ b/v2.3_CHANGELOG.md
@@ -41,6 +41,42 @@ automatic PR checklist. No integration behavior changed.
 - `CONTRIBUTING.md` — new
 - `.github/pull_request_template.md` — new
 
+## Documentation
+
+### External database: SQL sensor walkthrough (#63)
+
+Rewrote the *External Database* section with a complete, no-YAML setup guide
+for monitoring MariaDB or PostgreSQL via the SQL integration. Includes
+connection string template, the exact size query, column mapping, and the
+required Advanced Options (Unit of Measurement `MB`, Device Class `Data size`,
+State Class `Measurement`).
+
+**Files changed:**
+- `README.md` — *External Database* section
+
+### Setup paths corrected to "Devices & Services" (#66)
+
+Aligned all setup-path references with the current Home Assistant menu
+structure (`Settings > Devices & Services > …`). Replaces the legacy
+`Settings > Integrations > …` wording in the installation, options-flow,
+external-database and FAQ sections.
+
+**Files changed:**
+- `README.md` — installation, System Monitor prerequisite, External Database,
+  FAQ sections
+
+### UI Integration: clarified card YAML usage (#65)
+
+Issue #65 was closed as *wontfix* — the YAML samples in the README are
+card-level configuration and must be added via *Add Card → Manual* on a
+dashboard, not pasted into the raw dashboard editor (which expects a full
+`views:` structure). A short note will be added to the *UI Integration*
+intro in the upcoming Phase 4 README pass.
+
+> Independent finding from this review: the Lite card has an empty truthy
+> branch in the recommendations block (`{% if rec … %} {% else %} … {% endif %}`),
+> which means recommendations are never rendered. Tracked as a Phase 4 fix.
+
 ---
 
-*Last updated: 2026-04-12*
+*Last updated: 2026-05-08*


### PR DESCRIPTION
## v2.3 release candidate

Brings the `claude/plan-v2.3-roadmap-Sgi7J` feature branch into `dev` as a single squashed commit. Pre-release bumps (`manifest.json`, `hacs.json`, README changelog section) follow on `dev`. Tag and release ship after `dev → main`.

### Highlights

**New features**
- Multi-label ignore with dynamic toggling via HA-native `label.assign` / `label.remove` services
- Disabled-entity auto-ignore (`entity_registry.disabled_by` now respected, no `haghs_ignore` label required for disabled entities)
- `ZOMBIE_DOMAINS` expanded from 9 → 22 domains, new `zombie_count_per_domain` attribute, list cap raised 20 → 100
- Configurable zombie and battery grace periods in the Options Flow (1–240 min each, defaults 15 / 60)
- Pattern-based ignore for entities without a unique ID (`ignore_patterns`, glob syntax)
- 7-day update grace period, pending updates only contribute to the penalty after a week
- Boolean `rec_*` recommendation flags alongside the existing string
- PSI-aware recommendation text (CPU/RAM split into PSI vs classic variants)
- Power Supply Status detection for Raspberry Pi under-voltage
- Config Flow refactor + RepairsFlow recovers from PSI loss without restart
- Pro card bundle: `entity_id` alongside friendly name, separated ghost-zombie block, per-line pending updates, backward-compat for v2.2.2 consumers

**Bug fixes**
- `async_migrate_entry` shipped, closes the v2.2.2 "Migration handler not found" failure for v1/v2 entries
- Optional Options Flow fields (`db_sensor`, CPU/RAM fallback, ignore labels/patterns) now persist across HA restart when cleared
- App score hard-capped at 99 while zombies exist, config-audit bonus can no longer mask a real zombie
- Unregistered ghost zombies marked with `[unregistered]` prefix and warned once
- Registry-race guard via `EVENT_HOMEASSISTANT_STARTED` listener
- Restart grace via boot-time baseline so recorder-restored `last_changed` values don't bypass the window
- Battery-class entities get a separate, longer grace window
- `p_zombie` denominator counts only entities in `ZOMBIE_DOMAINS`
- Hassfest fixes (`vol.Exclusive` description-vs-fix_flow conflict, `actions/checkout` v3 → v5)

**Infrastructure**
- Test suite bootstrap: `pyproject.toml`, `requirements_test.txt`, seven test modules covering zombies, updates, application, hardware-power, migration, recommendations, options-flow persistence
- CI workflow `.github/workflows/ci.yml` runs pytest + ruff
- Release-notes augmentation workflow `.github/workflows/release-notes.yml` auto-injects coffee + contributors blocks into release bodies
- `.gitignore` and `CONTRIBUTING.md` refresh

**Documentation**
- External database walkthrough (no-YAML SQL-sensor setup, MariaDB query)
- Setup paths corrected throughout
- Pattern-Based Ignore documentation
- Full `v2.3_CHANGELOG.md` with the long-form story
- `ROADMAP.md` updated with completed v2.3 items and v2.4 "Stale-sensor detection" plan

### Issues to close at v2.3.0 release time

- #75 - Migration handler not found (verified resolved)
- #74 - verify scope before closing
- #62 - Registry-race guard + battery-class grace
- #61 - Hard-cap 99 + ghost marker
- #54 - Test infrastructure
- #21 - Power supply detection (verify scope)

### Test plan

- [x] `pytest` green across all seven test modules
- [x] `ruff check` + `ruff format --check` clean
- [x] Hassfest green
- [x] HACS validation green
- [ ] Manual smoke test on a real HA instance (post-merge to dev)
- [ ] Pre-release bumps on dev: `manifest.json` 2.2.2 → 2.3.0, `hacs.json` min HA → 2024.10.0, README `## Changelog` section

### Co-authorship

PR #49 (Config Flow refactor + RepairsFlow) was started by @gustavakerstrom and finalized on this branch. Credit preserved via `Co-authored-by:` trailer on the squash commit.